### PR TITLE
[gallery] Fix Gallery and Console

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,0 @@
-Brython - Python in the browser
-www.brython.info

--- a/site/benchmarks/index.html
+++ b/site/benchmarks/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <script type="text/javascript" src="../../src/brython.js"></script>
 
   <script type="text/python">
@@ -31,7 +32,7 @@
              if _test['name'] == name:
                 return _test['num_runs']
 
-         return 0 
+         return 0
 
      def run_tests(e):
          _tbody=doc.get(selector='tbody')[0]

--- a/site/brython.css
+++ b/site/brython.css
@@ -1,45 +1,55 @@
-body {font-family:arial,verdana;
-font-size:14px;
+@charset 'utf-8';
+@-ms-viewport{width:device-width};
+@-o-viewport{width:device-width};
+@viewport{width:device-width};
+
+
+#banner {
+  padding-bottom:15px;
+  width:85%
 }
-ul
-{
-list-style-type:none;
-margin:0;
-padding:0;
-overflow:hidden;
+
+#console {
+  background-color:#000;
+  color:#FFF;
+  font-weight:700
 }
-li
-{
-float:left;
+
+a.banner:hover,a.banner:active {
+  background:#000 url(doc/images/noir-2.png) repeat-x;
+  color:#FFF
 }
-a.banner:link,a.banner:visited
-{
-    display:block;
-    font-size:14px;
-    font-weight:bold;
-    color:#FFFFFF;
-    line-height:35px; /*hauteur de l'image de fond*/
-    background:black url(doc/images/noir-1.png) repeat-x;
-    padding:8px;
-    text-align:center;
-    text-decoration:none;
+
+a.banner:link,a.banner:visited {
+  background:#000 url(doc/images/noir-1.png) repeat-x;
+  color:#FFF;
+  display:block;
+  font-size:14px;
+  font-weight:700;
+  line-height:35px;
+  padding:8px;
+  text-align:center;
+  text-decoration:none
 }
-a.banner:hover,a.banner:active
-{
- background:black url(doc/images/noir-2.png) repeat-x;
- color:white;
+
+a.glink {
+  background-color:#FFF;
+  color:#000;
+  text-decoration:underline
 }
-#banner{
-    width:85%;
-    padding-bottom:15px;
+
+body {
+  font-family:Oxygen,arial;
+  font-size:14px
 }
-#console{
-    color:#FFF;
-    background-color:#000;
-    font-weight:bold;
+
+li {
+  float:left
 }
-a.glink{
-    text-decoration:underline;
-    background-color: #FFF;
-    color: #000;
+
+ul {
+  list-style-type:none;
+  margin:0;
+  overflow:hidden;
+  padding:0
 }

--- a/site/console.html
+++ b/site/console.html
@@ -1,194 +1,199 @@
 <!doctype html>
 <html>
 <head>
-<meta charset="iso-8859-1">
-<link rel="stylesheet" href="doc/doc_brython.css">
-
-<title>brython interactive mode</title>
-<script type="text/javascript" src="../src/brython.js"></script>
-
-<style>
-div,
-textarea {
-    width:98%;
-    height:100%;
-}
-.codeArea {
-  overflow: auto;
-  background-color: #000000;
-  color: #ffffff;
-  font-family: Consolas, Menlo, Monaco, 'Lucida Console', 'Liberation Mono', 
-      'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New', monospace, serif;
-  font-size: 14px;
-}
-</style>
-
+    <title>Brython interactive mode</title>
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython >
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="doc/doc_brython.css">
+    <script src="../src/brython.js" async onload=brython(1) ></script>
+    <style>
+    .codearea {
+        background-color:#000;
+        color:#fff;
+        font-family:'Oxygen Mono', Consolas, 'Liberation Mono', 'DejaVu Sans Mono', monospace;
+        font-size:14px;
+        overflow:auto
+    }
+    div, textarea {
+        height:100%;
+        width:98%
+    }
+    </style>
 </head>
-<body onload="brython(1)"><!-- remove the 1 to leave debug mode -->
 
-<table id="banner" cellpadding=0 cellspacing=0>
-<tr id="banner_row">
-</tr>
-</table>
 
-<textarea id="code" class="codeArea" rows=20></textarea>
+<body>
+    <table id=banner cellpadding=0 cellspacing=0>
+        <tr id=banner_row >
+    </table>
 
-<div id="content"></div>
+    <textarea id=code class=codearea rows=20></textarea>
 
-<script type="text/python3">
-import sys
-import traceback
+    <div id=content></div>
 
-from browser import document as doc
-from browser import window as win
 
-history = []
-current = 0
+    <script type="text/python3">
+    import sys
+    import traceback
 
-def write(data):
-    doc['code'].value += data
+    from browser import document as doc
+    from browser import window as win
 
-sys.stdout.write = sys.stderr.write = write
 
-_status = "main" # or "block" if typing inside a block
+    def write(data):
+        doc['code'].value += data
 
-def cursorToEnd(*args):
-    pos = len(doc['code'].value)
-    doc['code'].setSelectionRange(pos,pos)
 
-def get_col(area):
-    # returns the column num of cursor
-    sel = doc['code'].selectionStart
-    lines = doc['code'].value.split('\n')
-    for line in lines[:-1]:
-        sel -= len(line)+1
-    return sel
+    sys.stdout.write = sys.stderr.write = write
+    history = []
+    current = 0
+    _status = "main"  # or "block" if typing inside a block
+    editor_ns = {}  # namespace
 
-editor_ns = {} # namespace
 
-def myKeyPress(event):
-    global _status,current
-    
-    if event.keyCode == 9: # tab key
-        event.preventDefault()
-        doc['code'].value += "    "
-    elif event.keyCode == 13:    # return
-        src = doc['code'].value
-        if _status == "main":
-            currentLine = src[src.rfind('>>>')+4:]
-        elif _status == "3string":
-            currentLine = src[src.rfind('>>>')+4:]
-            currentLine = currentLine.replace('\n... ','\n')
-        else:
-            currentLine = src[src.rfind('...')+4:]
+    def cursorToEnd(*args):
+        pos = len(doc['code'].value)
+        doc['code'].setSelectionRange(pos, pos)
 
-        if _status == 'main' and not currentLine.strip():
-            doc['code'].value += '\n>>> '
+
+    def get_col(area):
+        # returns the column num of cursor
+        sel = doc['code'].selectionStart
+        lines = doc['code'].value.split('\n')
+        for line in lines[:-1]:
+            sel -= len(line) + 1
+        return sel
+
+
+    def myKeyPress(event):
+        global _status, current
+        if event.keyCode == 9:  # tab key
             event.preventDefault()
-            return
-        doc['code'].value+='\n'
-        history.append(currentLine)
-        current += 1
-        if _status == "main" or _status == "3string":
-            try:
-                _ = exec(currentLine,editor_ns)
-                if _ is not None:
-                    print(repr(_))
-                doc['code'].value += '>>> '
-                _status = "main"
-            except IndentationError:
-                doc['code'].value += '... '
-                _status = "block"
-            except SyntaxError as msg:
-                if str(msg) == 'invalid syntax : triple string end not found' or\
-                    str(msg).startswith('Unbalanced bracket'):
+            doc['code'].value += "    "
+        elif event.keyCode == 13:  # return
+            src = doc['code'].value
+            if _status == "main":
+                currentLine = src[src.rfind('>>>') + 4:]
+            elif _status == "3string":
+                currentLine = src[src.rfind('>>>') + 4:]
+                currentLine = currentLine.replace('\n... ', '\n')
+            else:
+                currentLine = src[src.rfind('...') + 4:]
+            if _status == 'main' and not currentLine.strip():
+                doc['code'].value += '\n>>> '
+                event.preventDefault()
+                return
+            doc['code'].value += '\n'
+            history.append(currentLine)
+            current += 1
+            if _status == "main" or _status == "3string":
+                try:
+                    _ = exec(currentLine, editor_ns)
+                    if _ is not None:
+                        print(repr(_))
+                    doc['code'].value += '>>> '
+                    _status = "main"
+                except IndentationError:
                     doc['code'].value += '... '
-                    _status = "3string"
-                else:
+                    _status = "block"
+                except SyntaxError as msg:
+                    if str(msg) == 'invalid syntax : triple string end not found' or \
+                        str(msg).startswith('Unbalanced bracket'):
+                        doc['code'].value += '... '
+                        _status = "3string"
+                    else:
+                        traceback.print_exc()
+                        doc['code'].value += '>>> '
+                        _status = "main"
+                except:
                     traceback.print_exc()
                     doc['code'].value += '>>> '
                     _status = "main"
-            except:
-                traceback.print_exc()
-                doc['code'].value += '>>> '
+            elif currentLine == "":  # end of block
+                block = src[src.rfind('>>>') + 4:].splitlines()
+                block = [block[0]] + [b[4:] for b in block[1:]]
+                block_src = '\n'.join(block)
+                # status must be set before executing code in globals()
                 _status = "main"
-        elif currentLine == "": # end of block
-            block = src[src.rfind('>>>')+4:].splitlines()
-            block = [block[0]]+[b[4:] for b in block[1:]]
-            block_src = '\n'.join(block)
-            
-            # status must be set before executing code in globals()
-            _status = "main"
-            
-            try:
-                _ = exec(block_src,editor_ns)
-                if _ is not None:
-                    print(repr(_))
-            except:
-                traceback.print_exc()
-            doc['code'].value += '>>> '
-        else:
-            doc['code'].value += '... '        
-        cursorToEnd()
-        event.preventDefault()
-        #event.stopPropagation()
-
-def myKeyDown(event):
-    global _status,current
-    
-    if event.keyCode == 37: # left arrow
-        sel = get_col(doc['code'])
-        if sel<5:
+                try:
+                    _ = exec(block_src, editor_ns)
+                    if _ is not None:
+                        print(repr(_))
+                except:
+                    traceback.print_exc()
+                doc['code'].value += '>>> '
+            else:
+                doc['code'].value += '... '
+            cursorToEnd()
             event.preventDefault()
-            event.stopPropagation()
-    elif event.keyCode == 36: # line start
-        pos = doc['code'].selectionStart
-        col = get_col(doc['code'])
-        doc['code'].setSelectionRange(pos-col+4,pos-col+4)
-        event.preventDefault()
-    elif event.keyCode == 38: # up
-        if current > 0:
+            #event.stopPropagation()
+
+
+    def myKeyDown(event):
+        global _status, current
+        if event.keyCode == 37:  # left arrow
+            sel = get_col(doc['code'])
+            if sel < 5:
+                event.preventDefault()
+                event.stopPropagation()
+        elif event.keyCode == 36:  # line start
             pos = doc['code'].selectionStart
             col = get_col(doc['code'])
-            # remove current line
-            doc['code'].value = doc['code'].value[:pos-col+4]
-            current -= 1
-            doc['code'].value += history[current]
-        event.preventDefault()
-    elif event.keyCode == 40: # down
-        if current < len(history)-1:
-            pos = doc['code'].selectionStart
-            col = get_col(doc['code'])
-            # remove current line
-            doc['code'].value = doc['code'].value[:pos-col+4]
-            current += 1
-            doc['code'].value += history[current]
-        event.preventDefault()
-    elif event.keyCode == 8: # backspace
-        src = doc['code'].value
-        lstart = src.rfind('\n')
-        if (lstart==-1 and len(src)<5) \
-            or (len(src)-lstart<6):
+            doc['code'].setSelectionRange(pos - col + 4, pos - col + 4)
+            event.preventDefault()
+        elif event.keyCode == 38:  # up
+            if current > 0:
+                pos = doc['code'].selectionStart
+                col = get_col(doc['code'])
+                # remove current line
+                doc['code'].value = doc['code'].value[:pos - col + 4]
+                current -= 1
+                doc['code'].value += history[current]
+            event.preventDefault()
+        elif event.keyCode == 40:  # down
+            if current < len(history) - 1:
+                pos = doc['code'].selectionStart
+                col = get_col(doc['code'])
+                # remove current line
+                doc['code'].value = doc['code'].value[:pos - col + 4]
+                current += 1
+                doc['code'].value += history[current]
+            event.preventDefault()
+        elif event.keyCode == 8:  # backspace
+            src = doc['code'].value
+            lstart = src.rfind('\n')
+            if (lstart == -1 and len(src) < 5) or (len(src) - lstart < 6):
                 event.preventDefault()
                 event.stopPropagation()
 
-doc['code'].bind('keypress', myKeyPress)
-doc['code'].bind('keydown', myKeyDown)
-doc['code'].bind('click', cursorToEnd)
-v = sys.implementation.version
-    
-doc['code'].value = "Brython %s.%s.%s on %s %s\n>>> " %(v[0],v[1],v[2],
-    win.navigator.appName,win.navigator.appVersion)
-doc['code'].focus()
-cursorToEnd()
+
+    doc['code'].bind('keypress', myKeyPress)
+    doc['code'].bind('keydown', myKeyDown)
+    doc['code'].bind('click', cursorToEnd)
+    v = sys.implementation.version
+    doc['code'].value = "Brython %s.%s.%s on %s %s\n>>> " % (
+        v[0], v[1], v[2], win.navigator.appName, win.navigator.appVersion)
+    doc['code'].focus()
+    cursorToEnd()
+    </script>
 
 
-</script>
-<p>The console can be embedded in a web page by adding
-<blockquote>
-<pre>
-&lt;iframe src="http://brython.info/console.html" width=800 height=400&gt;&lt;/iframe&gt;
-</pre></blockquote>
+    <details>
+        <summary>Embed:</summary>
+            The console can be embedded in a web page by adding
+        <blockquote>
+            <pre>
+                &lt;iframe src=http://brython.info/console.html width=800 height=400&gt;&lt;/iframe&gt;
+            </pre>
+        </blockquote>
+    </details>
 
 </body>
+
 </html>

--- a/site/doc/doc_brython.css
+++ b/site/doc/doc_brython.css
@@ -1,96 +1,116 @@
-body,td {font-family:arial,verdana;
-font-size:13px;
-margin:0px;
+@charset 'utf-8';
+@-ms-viewport{width:device-width};
+@-o-viewport{width:device-width};
+@viewport{width:device-width};
 
-}
-a.navig:link,a.navig:visited { 
-    text-decoration: none;
-    color:#1767B7;
+
+body,td {
+  font-family:Oxygen,arial;
+  font-size:13px;
+  margin:0
 }
 
-a.banner:link,a.banner:visited
-{
-    display:block;
-    font-size:16px;
-    color:#FFFFFF;
-    line-height:30px; /*hauteur de l'image de fond*/
-    background-color:#1767B7;
-    padding:10px;
-    text-align:center;
-    text-decoration:none;
+a.navig:link,a.navig:visited {
+  color:#1767B7;
+  text-decoration:none
 }
-a.banner:hover,a.banner:active
-{
- background-color:#2070C0;
- color:white;
+
+a.banner:link,a.banner:visited {
+  background-color:#1767B7;
+  color:#FFF;
+  display:block;
+  font-size:16px;
+  line-height:30px;
+  padding:10px;
+  text-align:center;
+  text-decoration:none
 }
-#banner{
-    width:100%;
-    padding-bottom:15px;
+
+a.banner:hover,a.banner:active {
+  background-color:#2070C0;
+  color:#FFF
 }
-#console{
-    color:#FFF;
-    background-color:#000;
-    font-weight:bold;
-    font-size:12px;
+
+#banner {
+  padding-bottom:15px;
+  width:100%
 }
+
+#console {
+  background-color:#000;
+  color:#FFF;
+  font-size:12px;
+  font-weight:700
+}
+
 #content {
-    padding-left:5%;
-    padding-right:5%;
-    
+  padding-left:5%;
+  padding-right:5%
 }
-a.glink{
-    text-decoration:underline;
-    background-color: #FFF;
-    color: #000;
+
+a.glink {
+  background-color:#FFF;
+  color:#000;
+  text-decoration:underline
 }
+
 img.logo {
-    height: 28px;
-    padding:0px;
-    border-width:0px;
-    width:auto;
+  border-width:0;
+  height:28px;
+  padding:0;
+  width:auto
 }
+
 td.logo {
-    padding-left:20px;
-    background-color:#1767B7;
-    width:15%;
+  background-color:#1767B7;
+  padding-left:20px;
+  width:15%
 }
-td.top_menu{
-    width:10%;
+
+td.top_menu {
+  width:10%
 }
-td.language{
-    background-color:#1767B7;
-    text-align:right;
+
+td.language {
+  background-color:#1767B7;
+  text-align:right
 }
-select.language{
-    border-width:0px;
-    font-size:14px;
-    color:#000;
-    padding:10px;
-    margin-left:10px;
+
+select.language {
+  border-width:0;
+  color:#000;
+  font-size:14px;
+  margin-left:10px;
+  padding:10px
 }
+
 li {
-    margin-bottom: 3px;
+  margin-bottom:3px
 }
+
 pre.marked {
-    color: #339;
+  color:#339
 }
+
 code {
-    color: #339;
+  color:#339
 }
-em{
-    color: #339;
-    font-family:courier;
+
+em {
+  color:#339;
+  font-family:Oxygen,courier
 }
-strong{
-    color: #339;
-    font-family:courier;
+
+strong {
+  color:#339;
+  font-family:Oxygen,courier
 }
+
 #main {
-    border-style: solid;
-    border-width: 1px;
-    border-color: #000;
-    padding: 5px;
-    min-height:20px;
-    min-width:200px;
+  border-color:#000;
+  border-style:solid;
+  border-width:1px;
+  min-height:20px;
+  min-width:200px;
+  padding:5px
 }

--- a/site/gallery/gallery_en.html
+++ b/site/gallery/gallery_en.html
@@ -1,80 +1,121 @@
-
-<!DOCTYPE html>
+<!doctype html>
 <html>
 <head>
-<meta name="description" content="Brython">
-<meta name="keywords" content="Python,Brython">
-<meta name="author" content="Pierre Quentel">
-<meta charset="utf-8">
-<link rel="stylesheet" href="../doc/doc_brython.css">
-<script src="../../src/brython.js"></script>
-
-<title>Brython</title>
-
-<script type="text/python3">
-import header
-header.show('../')
-</script>
+    <title>Brython</title>
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython >
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="../doc/doc_brython.css">
+    <style>
+    .layered-paper {
+        position:relative;
+        background: #eee;
+        width:99%;
+        box-shadow: 0 1px 1px rgba(0,0,0,.2), 0 10px 0 -5px #eee, 0 10px 1px -4px rgba(0,0,0,.2), 0 20px 0 -10px #eee, 0 20px 1px -9px rgba(0,0,0,.2);
+        background-image:
+            linear-gradient(90deg, transparent 46%, gray 50%, lightgray 52%, transparent 55%),
+            linear-gradient(lightgray .1em, transparent .1em);
+        background-size: 100% 1.2em;
+        margin:26px auto 0;
+        max-width:900px;
+        min-height:400px;
+        padding:24px;
+        position:relative;
+        font-family:Oxygen,Helvetica;
+        text-align:center
+    }
+    .layered-paper:before, .layered-paper:after {
+        content:"";
+        position:absolute;
+        z-index:-1;
+        -webkit-box-shadow:0 0 20px rgba(0,0,0,.9);
+        -moz-box-shadow:0 0 20px rgba(0,0,0,.9);
+        box-shadow:0 0 20px rgba(0,0,0,.9);
+        top:9px;
+        bottom:9px;
+        left:0;
+        right:0;
+        -moz-border-radius:99px / 9px;
+        border-radius:99px / 9px
+    }
+    .layered-paper:after {
+        right:9px;
+        left:auto;
+        -webkit-transform:skew(8deg) rotate(3deg);
+        -moz-transform:skew(8deg) rotate(3deg);
+        transform:skew(8deg) rotate(3deg)
+    }
+    </style>
+    <script src="../../src/brython.js" async onload=brython(1) ></script>
+    <script type="text/python3">
+    import header
+    header.show('../')
+    </script>
 </head>
 
-<body onload="brython(1)">
 
-<table id="banner" cellpadding=0 cellspacing=0>
-<tr id="banner_row">
-</tr>
-</table>
+<body>
 
-<div style="text-align:center">
+    <table id=banner cellpadding=0 cellspacing=0>
+        <tr id=banner_row >
+    </table>
 
-<h2>Gallery</h2>
+    <div style="text-align:center">
 
-<table width="100%">
-<tr>
-<td valign="top">
-<h3>Brython</h3>
+        <table class="layered-paper">
+        <tr>
+        <td valign="top">
+        <h3>Brython</h3>
 
-<p><a class="glink" target="_blank" href="hello.html">Hello world !</a>
-<br><a target="_blank" href="ajax.html">ajax</a>
-<br><a target="_blank" href="sort_table.html">sort table</a>
+        <p><a class="glink" target=_blank href="hello.html">Hello world !</a>
+        <br><a target=_blank href="ajax.html">ajax</a>
+        <br><a target=_blank href="sort_table.html">sort table</a>
 
-<br>
-<br><a target="_blank" href="svg_pie_chart.html">SVG pie chart</a>
-<br><a target="_blank" href="solitaire.html">SVG solitaire game</a>
-<br><a target="_blank" href="sudoku.html">sudoku</a>
-<br><a target="_blank" href="compass.html">SVG compass</a> by Nicolas Pinault (works on some mobiles)
-<br><a target="_blank" href="geo.html">geolocation</a> by François Dion
-<br><a target="_blank" href="ruskey.html">Russian keyboard</a> by François Dion
-<br><a target="_blank" href="kanban.html">pseudo Kanban simulator</a> by Pedro Rodriguez
-<br><a target="_blank" href="ui/index.html">UI Components</a> by Billy Earney
-<br><a target="_blank" href="unbind.html">bind and unbind events</a>
-<br><a target="_blank" href="battery.html">battery load</a> by Nicolas Pinault
-<br><a target="_blank" href="barcode.html">barcode</a> by Carl Smith
-<br><a target="_blank" href="http://brython.info/cours_python/cours_python.html">Python tutorial slideshow (in French)</a>
+        <br>
+        <br><a target=_blank href="svg_pie_chart.html">SVG pie chart</a>
+        <br><a target=_blank href="solitaire.html">SVG solitaire game</a>
+        <br><a target=_blank href="sudoku.html">sudoku</a>
+        <br><a target=_blank href="compass.html">SVG compass</a> by Nicolas Pinault<br>(works on some mobiles)
+        <br><a target=_blank href="geo.html">geolocation</a> by François Dion
+        <br><a target=_blank href="ruskey.html">Russian keyboard</a> by François Dion
+        <br><a target=_blank href="kanban.html">pseudo Kanban simulator</a> by Pedro Rodriguez
+        <br><a target=_blank href="ui/index.html">UI Components</a> by Billy Earney
+        <br><a target=_blank href="unbind.html">bind and unbind events</a>
+        <br><a target=_blank href="battery.html">battery load</a> by Nicolas Pinault
+        <br><a target=_blank href="barcode.html">barcode</a> by Carl Smith
+        <br><a target=_blank href="http://brython.info/cours_python/cours_python.html">Python tutorial slideshow (in French)</a>
 
-<p><i>next examples require HTML5</i>
-<br><a target="_blank" href="clock.html">analog clock</a>
-<br><a target="_blank" href="europe.html">drag and drop</a>
-<br><a target="_blank" href="drop_files.html">drag and drop files</a> by Glenn Linderman
-<br><a target="_blank" href="sheet.html">local storage</a>
-<br><a target="_blank" href="canvas_plot.html">Python plot on the web</a> by Kiko Correoso
-<br><a target="_blank" href="3Dwalker.html">3D walker</a>
-<br><a target="_blank" href="compass.html">compass (svg)</a>
+        <p><i>next examples require HTML5</i>
+        <br><a target=_blank href="clock.html">analog clock</a>
+        <br><a target=_blank href="europe.html">drag and drop</a>
+        <br><a target=_blank href="drop_files.html">drag and drop files</a> by Glenn Linderman
+        <br><a target=_blank href="sheet.html">local storage</a>
+        <br><a target=_blank href="canvas_plot.html">Python plot on the web</a> by Kiko Correoso
+        <br><a target=_blank href="3Dwalker.html">3D walker</a>
+        <br><a target=_blank href="compass.html">compass (svg)</a>
 
 
-</td>
+        </td>
 
-<td valign="top">
-<h3>Interaction with Javascript libraries</h3>
+        <td valign="top">
+        <h3>Interaction with Javascript libraries</h3>
 
-<a target="_blank" href="three.html">3D animation 3D with three.js</a> by Dirk Krause
-<br><a target="_blank" href="raphael">Raphael (vector graphics)</a>
-<br><a target="_blank" href="highcharts">Highcharts (interactive charts)</a>
+        <a target=_blank href="three.html">3D animation 3D with three.js</a> by Dirk Krause
+        <br><a target=_blank href="raphael">Raphael (vector graphics)</a>
+        <br><a target=_blank href="highcharts">Highcharts (interactive charts)</a>
 
-</td>
-</tr>
-</table>
+        </td>
+        </tr>
+        </table>
+    </div>
+    <br>
 
-</div>
+
 </body>
-</html>
 
+</html>

--- a/site/gallery/gallery_es.html
+++ b/site/gallery/gallery_es.html
@@ -1,30 +1,76 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 <head>
-<meta name="description" content="Brython">
-<meta name="keywords" content="Python,Brython">
-<meta name="author" content="Pierre Quentel">
-<meta http-equiv="content-type" content="text/html;charset=utf-8">
-<link rel="stylesheet" href="../doc/doc_brython.css">
-<script src="../../src/brython.js"></script>
-
-<title>Brython</title>
-<script type="text/python3">
-import header
-header.show('../')
-</script>
+    <title>Brython</title>
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython >
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="../doc/doc_brython.css">
+    <style>
+    .layered-paper {
+        position:relative;
+        background: #eee;
+        width:99%;
+        box-shadow: 0 1px 1px rgba(0,0,0,.2), 0 10px 0 -5px #eee, 0 10px 1px -4px rgba(0,0,0,.2), 0 20px 0 -10px #eee, 0 20px 1px -9px rgba(0,0,0,.2);
+        background-image:
+            linear-gradient(90deg, transparent 46%, gray 50%, lightgray 52%, transparent 55%),
+            linear-gradient(lightgray .1em, transparent .1em);
+        background-size: 100% 1.2em;
+        margin:26px auto 0;
+        max-width:900px;
+        min-height:400px;
+        padding:24px;
+        position:relative;
+        font-family:Oxygen,Helvetica;
+        text-align:center
+    }
+    .layered-paper:before, .layered-paper:after {
+        content:"";
+        position:absolute;
+        z-index:-1;
+        -webkit-box-shadow:0 0 20px rgba(0,0,0,.9);
+        -moz-box-shadow:0 0 20px rgba(0,0,0,.9);
+        box-shadow:0 0 20px rgba(0,0,0,.9);
+        top:9px;
+        bottom:9px;
+        left:0;
+        right:0;
+        -moz-border-radius:99px / 9px;
+        border-radius:99px / 9px
+    }
+    .layered-paper:after {
+        right:9px;
+        left:auto;
+        -webkit-transform:skew(8deg) rotate(3deg);
+        -moz-transform:skew(8deg) rotate(3deg);
+        transform:skew(8deg) rotate(3deg)
+    }
+    </style>
+    <script src="../../src/brython.js" async onload=brython(1) ></script>
+    <script type="text/python3">
+    import header
+    header.show('../')
+    </script>
 </head>
 
-<body onload="brython(1)">
 
-<table id="banner" cellpadding=0 cellspacing=0>
-<tr id="banner_row">
-</tr>
-</table>
+<body>
 
-<div style="text-align:center">
+    <table id=banner cellpadding=0 cellspacing=0>
+        <tr id=banner_row >
+    </table>
 
-<h2>Galeria</h2>
+    <div style="text-align:center">
+
+        <table class="layered-paper">
+        <tr>
+        <td valign="top">
+        <h3>Brython</h3>
 <p><a class="glink" target="_blank" href="hello.html">Hello world !</a>
 <br><a target="_blank" href="ajax.html">ajax</a>
 <br><a target="_blank" href="sort_table.html">tabla en orden</a>
@@ -42,7 +88,10 @@ header.show('../')
 <br><a target="_blank" href="battery.html">carga de batería</a> por Nicolas Pinault
 <br><a target="_blank" href="barcode.html">código de barras</a> por Carl Smith
 <br><a target="_blank" href="http://brython.info/cours_python/cours_python.html">presentación del tutorial Python (en francés)</a>
+</td>
 
+        <td valign="top">
+        <h3>Interaction with Javascript libraries</h3>
 <p><a target="_blank" href="three.html">navigación 3D con three.js</a> por Dirk Krause
 
 <p><i>Estos ejemplos requieren HTML5</i>
@@ -52,8 +101,11 @@ header.show('../')
 <br><a target="_blank" href="sheet.html">local storage</a>
 <br><a target="_blank" href="canvas_plot.html">Python Plot on the web</a> por Kiko Correoso
 <br><a target="_blank" href="3Dwalker.html">navegación 3D</a>
+</table>
+    </div>
+    <br>
 
 
-</div>
 </body>
+
 </html>

--- a/site/gallery/gallery_fr.html
+++ b/site/gallery/gallery_fr.html
@@ -1,35 +1,76 @@
-
-<!DOCTYPE html>
+<!doctype html>
 <html>
 <head>
-<meta name="description" content="Brython">
-<meta name="keywords" content="Python,Brython">
-<meta name="author" content="Pierre Quentel">
-<meta charset="utf-8">
-<link rel="stylesheet" href="../doc/doc_brython.css">
-<script src="../../src/brython.js"></script>
-
-<title>Brython</title>
-<script type="text/python3">
-import header
-header.show('../')
-</script>
+    <title>Brython</title>
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython >
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="../doc/doc_brython.css">
+    <style>
+    .layered-paper {
+        position:relative;
+        background: #eee;
+        width:99%;
+        box-shadow: 0 1px 1px rgba(0,0,0,.2), 0 10px 0 -5px #eee, 0 10px 1px -4px rgba(0,0,0,.2), 0 20px 0 -10px #eee, 0 20px 1px -9px rgba(0,0,0,.2);
+        background-image:
+            linear-gradient(90deg, transparent 46%, gray 50%, lightgray 52%, transparent 55%),
+            linear-gradient(lightgray .1em, transparent .1em);
+        background-size: 100% 1.2em;
+        margin:26px auto 0;
+        max-width:900px;
+        min-height:400px;
+        padding:24px;
+        position:relative;
+        font-family:Oxygen,Helvetica;
+        text-align:center
+    }
+    .layered-paper:before, .layered-paper:after {
+        content:"";
+        position:absolute;
+        z-index:-1;
+        -webkit-box-shadow:0 0 20px rgba(0,0,0,.9);
+        -moz-box-shadow:0 0 20px rgba(0,0,0,.9);
+        box-shadow:0 0 20px rgba(0,0,0,.9);
+        top:9px;
+        bottom:9px;
+        left:0;
+        right:0;
+        -moz-border-radius:99px / 9px;
+        border-radius:99px / 9px
+    }
+    .layered-paper:after {
+        right:9px;
+        left:auto;
+        -webkit-transform:skew(8deg) rotate(3deg);
+        -moz-transform:skew(8deg) rotate(3deg);
+        transform:skew(8deg) rotate(3deg)
+    }
+    </style>
+    <script src="../../src/brython.js" async onload=brython(1) ></script>
+    <script type="text/python3">
+    import header
+    header.show('../')
+    </script>
 </head>
 
-<body onload="brython(1)">
 
-<table id="banner" cellpadding=0 cellspacing=0>
-<tr id="banner_row">
-</tr>
-</table>
+<body>
 
-<div style="text-align:center">
+    <table id=banner cellpadding=0 cellspacing=0>
+        <tr id=banner_row >
+    </table>
 
-<h2>Galerie</h2>
-<table width="100%">
-<tr>
-<td valign="top">
-<h3>Brython</h3>
+    <div style="text-align:center">
+
+        <table class="layered-paper">
+        <tr>
+        <td valign="top">
+        <h3>Brython</h3>
 <a class="glink" target="_blank" href="hello.html">Hello world !</a>
 <br><a target="_blank" href="ajax.html">ajax</a>
 <br><a target="_blank" href="sort_table.html">tri de table</a>
@@ -37,7 +78,7 @@ header.show('../')
 <br><a target="_blank" href="svg_pie_chart.html">camembert SVG</a>
 <br><a target="_blank" href="solitaire.html">jeu de solitaire en SVG</a>
 <br><a target="_blank" href="sudoku.html">sudoku</a>
-<br><a target="_blank" href="compass.html">boussole SVG</a> par Nicolas Pinault (fonctionne sur certains mobiles)
+<br><a target="_blank" href="compass.html">boussole SVG</a> par Nicolas Pinault<br>(fonctionne sur certains mobiles)
 <br><a target="_blank" href="geo.html">geolocalisation</a> par François Dion
 <br><a target="_blank" href="ruskey.html">clavier russe QWERTY</a> par François Dion
 <br><a target="_blank" href="kanban.html">simulateur Kanban</a> par Pedro Rodriguez
@@ -65,11 +106,14 @@ header.show('../')
 <br><a target="_blank" href="raphael">Raphael (graphiques vectoriel)</a>
 <br><a target="_blank" href="highcharts">Highcharts (courbes et graphes)</a>
 
-</td>
-</tr>
-</table>
+        </td>
+        </tr>
+        </table>
+    </div>
+    <br>
 
-</div>
+
 </body>
+
 </html>
 

--- a/site/gallery/gallery_pt.html
+++ b/site/gallery/gallery_pt.html
@@ -1,32 +1,77 @@
-
-<!DOCTYPE html>
+<!doctype html>
 <html>
 <head>
-<meta name="description" content="Brython">
-<meta name="keywords" content="Python,Brython">
-<meta name="author" content="Pierre Quentel">
-<meta charset="utf-8">
-<link rel="stylesheet" href="../doc/doc_brython.css">
-<script src="../../src/brython.js"></script>
-
-<title>Brython</title>
-
-<script type="text/python3">
-import header
-header.show('../')
-</script>
+    <title>Brython</title>
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython >
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="../doc/doc_brython.css">
+    <style>
+    .layered-paper {
+        position:relative;
+        background: #eee;
+        width:99%;
+        box-shadow: 0 1px 1px rgba(0,0,0,.2), 0 10px 0 -5px #eee, 0 10px 1px -4px rgba(0,0,0,.2), 0 20px 0 -10px #eee, 0 20px 1px -9px rgba(0,0,0,.2);
+        background-image:
+            linear-gradient(90deg, transparent 46%, gray 50%, lightgray 52%, transparent 55%),
+            linear-gradient(lightgray .1em, transparent .1em);
+        background-size: 100% 1.2em;
+        margin:26px auto 0;
+        max-width:900px;
+        min-height:400px;
+        padding:24px;
+        position:relative;
+        font-family:Oxygen,Helvetica;
+        text-align:center
+    }
+    .layered-paper:before, .layered-paper:after {
+        content:"";
+        position:absolute;
+        z-index:-1;
+        -webkit-box-shadow:0 0 20px rgba(0,0,0,.9);
+        -moz-box-shadow:0 0 20px rgba(0,0,0,.9);
+        box-shadow:0 0 20px rgba(0,0,0,.9);
+        top:9px;
+        bottom:9px;
+        left:0;
+        right:0;
+        -moz-border-radius:99px / 9px;
+        border-radius:99px / 9px
+    }
+    .layered-paper:after {
+        right:9px;
+        left:auto;
+        -webkit-transform:skew(8deg) rotate(3deg);
+        -moz-transform:skew(8deg) rotate(3deg);
+        transform:skew(8deg) rotate(3deg)
+    }
+    </style>
+    <script src="../../src/brython.js" async onload=brython(1) ></script>
+    <script type="text/python3">
+    import header
+    header.show('../')
+    </script>
 </head>
 
-<body onload="brython(1)">
 
-<table id="banner" cellpadding=0 cellspacing=0>
-<tr id="banner_row">
-</tr>
-</table>
+<body>
 
-<div style="text-align:center">
+    <table id=banner cellpadding=0 cellspacing=0>
+        <tr id=banner_row >
+    </table>
 
-<h2>Galeria</h2>
+    <div style="text-align:center">
+
+        <table class="layered-paper">
+        <tr>
+        <td valign="top">
+        <h3>Brython</h3>
+
 <p><a class="glink" target="_blank" href="hello.html">Hello world !</a>
 <br><a target="_blank" href="ajax.html">ajax</a>
 <br><a target="_blank" href="sort_table.html">tabela ordenada</a>
@@ -44,6 +89,12 @@ header.show('../')
 <br><a target="_blank" href="unbind.html">eventos vincular e desvincular</a>
 <br><a target="_blank" href="battery.html">carga da bateria</a> por Nicolas Pinault
 <br><a target="_blank" href="barcode.html">código de barras</a> por Carl Smith
+
+        </td>
+
+        <td valign="top">
+        <h3>Interaction with Javascript libraries</h3>
+
 <p><a target="_blank" href="three.html">andarilho 3D com three.js</a> por Dirk Krause
 
 <p><i>Estes exemplos requerem HTML5</i>
@@ -53,8 +104,13 @@ header.show('../')
 <br><a target="_blank" href="canvas_plot.html">Python plot on the web</a> por Kiko Correoso
 <br><a target="_blank" href="3Dwalker.html">andarilho 3D</a>
 
+        </td>
+        </tr>
+        </table>
+    </div>
+    <br>
 
-</div>
+
 </body>
-</html>
 
+</html>

--- a/site/groups.html
+++ b/site/groups.html
@@ -3,13 +3,15 @@
 
 <head>
     <title>Brython</title>
-    <meta charset="UTF-8">
-    <meta name="description" content="Brython">
-    <meta name="author" content="Pierre Quentel">
-    <meta name="keywords" content="Python, Brython">
-    <meta http-equiv="content-type" content="text/html">
-    <link rel="stylesheet" href="doc/doc_brython.css">
-    <link rel="shortcut icon" href="brython.png" type="image/x-icon">
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython>
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="doc/doc_brython.css">
     <style>
         .letter {
             background-color: #fff;
@@ -24,7 +26,7 @@
             padding:24px;
             position:relative;
             width:80%;
-            font-family:Helvetica, sans-serif;
+            font-family:Oxygen,Helvetica;
             text-align:center
         }
         .letter:before, .letter:after {
@@ -54,30 +56,30 @@
             font-size: 20px
         }
     </style>
-    <script src="../src/brython.js"></script>
+    <script src="../src/brython.js" async onload=brython(1) ></script>
     <script type="text/python3">
     import header
     qs_lang, language = header.show()
     </script>
-
 </head>
 
-<body onload="brython(1)">
+
+<body>
 
     <table id="banner" cellpadding=0 cellspacing=0>
         <tr id="banner_row">
     </table>
 
     <div class="letter">
-    <h1 id="groups">Groups</h1>
-    <hr>
-    <ul>
-        <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython" target=_blank >Group (English)</a>
-        <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-fr" target=_blank >Groupe (français)</a>
-        <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-es" target=_blank >Grupo (español)</a>
-        <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-pt" target=_blank >Grupo (português)</a>
-        <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-it" target=_blank >Gruppo (italiano)</a>
-    </ul>
+        <h1 id="groups">Groups</h1>
+        <hr>
+        <ul>
+            <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython" target=_blank >Group (English)</a>
+            <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-fr" target=_blank >Groupe (français)</a>
+            <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-es" target=_blank >Grupo (español)</a>
+            <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-pt" target=_blank >Grupo (português)</a>
+            <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/brython-it" target=_blank >Gruppo (italiano)</a>
+        </ul>
     </div>
 
 </body>

--- a/site/tests/console.html
+++ b/site/tests/console.html
@@ -1,220 +1,223 @@
 <!doctype html>
 <html>
 <head>
-<meta charset="iso-8859-1">
-<link rel="stylesheet" href="../doc/doc_brython.css">
-
-<title>brython interactive mode</title>
-<script type="text/javascript" src="../../src/brython_builtins.js"></script>
-<script type="text/javascript" src="../../src/version_info.js"></script>
-<script type="text/javascript" src="../../src/identifiers_re.js"></script>
-<script type="text/javascript" src="../../src/py2js.js"></script>
-<script type="text/javascript" src="../../src/py_object.js"></script>
-<script type="text/javascript" src="../../src/py_type.js"></script>
-<script type="text/javascript" src="../../src/py_utils.js"></script>
-<script type="text/javascript" src="../../src/py_generator.js"></script>
-<script type="text/javascript" src="../../src/py_builtin_functions.js"></script>
-<script type="text/javascript" src="../../src/py_bytes.js"></script>
-<script type="text/javascript" src="../../src/py_set.js"></script>
-<script type="text/javascript" src="../../src/js_objects.js"></script>
-<script type="text/javascript" src="../../src/stdlib_paths.js"></script>
-<script type="text/javascript" src="../../src/py_import.js"></script>
-
-<script type="text/javascript" src="../../src/py_string.js"></script>
-<script type="text/javascript" src="../../src/py_int.js"></script>
-<script type="text/javascript" src="../../src/py_float.js"></script>
-<script type="text/javascript" src="../../src/py_complex.js"></script>
-<script type="text/javascript" src="../../src/py_dict.js"></script>
-<script type="text/javascript" src="../../src/py_list.js"></script>
-<script type="text/javascript" src="../../src/py_dom.js"></script>
-
-<style>
-div,
-textarea {
-    width:98%;
-    height:100%;
-}
-.codeArea {
-  overflow: auto;
-  background-color: #000000;
-  color: #ffffff;
-  font-family: Consolas, Menlo, Monaco, 'Lucida Console', 'Liberation Mono', 
-      'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New', monospace, serif;
-  font-size: 14px;
-}
-</style>
-<script type="text/python3">
-import header
-
-qs_lang,language = header.show('../')
-
-</script>
-
+    <title>Brython interactive mode</title>
+    <meta charset=UTF-8>
+    <meta name=robots content="index, follow">
+    <meta name=description content=Brython >
+    <meta name=author content="Pierre Quentel">
+    <meta name=keywords content="Python, Brython">
+    <meta name=viewport content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link rel="shortcut icon" href=brython.png type=image/x-icon >
+    <noscript>Please enable Javascript to view this page correctly.</noscript>
+    <link rel=stylesheet href="../doc/doc_brython.css">
+    <script type="text/javascript" src="../../src/brython_builtins.js"></script>
+    <script type="text/javascript" src="../../src/version_info.js"></script>
+    <script type="text/javascript" src="../../src/identifiers_re.js"></script>
+    <script type="text/javascript" src="../../src/py2js.js"></script>
+    <script type="text/javascript" src="../../src/py_object.js"></script>
+    <script type="text/javascript" src="../../src/py_type.js"></script>
+    <script type="text/javascript" src="../../src/py_utils.js"></script>
+    <script type="text/javascript" src="../../src/py_generator.js"></script>
+    <script type="text/javascript" src="../../src/py_builtin_functions.js"></script>
+    <script type="text/javascript" src="../../src/py_bytes.js"></script>
+    <script type="text/javascript" src="../../src/py_set.js"></script>
+    <script type="text/javascript" src="../../src/js_objects.js"></script>
+    <script type="text/javascript" src="../../src/stdlib_paths.js"></script>
+    <script type="text/javascript" src="../../src/py_import.js"></script>
+    <script type="text/javascript" src="../../src/py_string.js"></script>
+    <script type="text/javascript" src="../../src/py_int.js"></script>
+    <script type="text/javascript" src="../../src/py_float.js"></script>
+    <script type="text/javascript" src="../../src/py_complex.js"></script>
+    <script type="text/javascript" src="../../src/py_dict.js"></script>
+    <script type="text/javascript" src="../../src/py_list.js"></script>
+    <script type="text/javascript" src="../../src/py_dom.js"></script>
+    <script type="text/python3">
+    import header
+    qs_lang, language = header.show('../')
+    </script>
+    <style>
+    .codearea {
+        background-color:#000;
+        color:#fff;
+        font-family:'Oxygen Mono', Consolas, 'Liberation Mono', 'DejaVu Sans Mono', monospace;
+        font-size:14px;
+        overflow:auto
+    }
+    div, textarea {
+        height:100%;
+        width:98%
+    }
+    </style>
 </head>
+
+
 <body onload="brython(1)"><!-- remove the 1 to leave debug mode -->
+    <table id=banner cellpadding=0 cellspacing=0>
+        <tr id=banner_row >
+    </table>
 
-<table id="banner" cellpadding=0 cellspacing=0>
-<tr id="banner_row">
-</tr>
-</table>
+    <textarea id=code class=codearea rows=20></textarea>
 
-<textarea id="code" class="codeArea" rows=20></textarea>
+    <div id=content></div>
 
-<div id="content"></div>
 
-<script type="text/python3">
-import sys
-import traceback
+    <script type="text/python3">
+    import sys
+    import traceback
 
-from browser import document as doc
-from browser import window as win
+    from browser import document as doc
+    from browser import window as win
 
-history = []
-current = 0
 
-def write(data):
-    doc['code'].value += data
+    def write(data):
+        doc['code'].value += data
 
-sys.stdout.write = sys.stderr.write = write
 
-_status = "main" # or "block" if typing inside a block
+    sys.stdout.write = sys.stderr.write = write
+    history = []
+    current = 0
+    _status = "main"  # or "block" if typing inside a block
+    editor_ns = {}  # namespace
 
-def cursorToEnd(*args):
-    pos = len(doc['code'].value)
-    doc['code'].setSelectionRange(pos,pos)
 
-def get_col(area):
-    # returns the column num of cursor
-    sel = doc['code'].selectionStart
-    lines = doc['code'].value.split('\n')
-    for line in lines[:-1]:
-        sel -= len(line)+1
-    return sel
+    def cursorToEnd(*args):
+        pos = len(doc['code'].value)
+        doc['code'].setSelectionRange(pos, pos)
 
-editor_ns = {} # namespace
 
-def myKeyPress(event):
-    global _status,current
-    
-    if event.keyCode == 9: # tab key
-        event.preventDefault()
-        doc['code'].value += "    "
-    elif event.keyCode == 13:    # return
-        src = doc['code'].value
-        if _status == "main":
-            currentLine = src[src.rfind('>>>')+4:]
-        elif _status == "3string":
-            currentLine = src[src.rfind('>>>')+4:]
-            currentLine = currentLine.replace('\n... ','\n')
-        else:
-            currentLine = src[src.rfind('...')+4:]
+    def get_col(area):
+        # returns the column num of cursor
+        sel = doc['code'].selectionStart
+        lines = doc['code'].value.split('\n')
+        for line in lines[:-1]:
+            sel -= len(line) + 1
+        return sel
 
-        if _status == 'main' and not currentLine.strip():
-            doc['code'].value += '\n>>> '
+
+    def myKeyPress(event):
+        global _status, current
+        if event.keyCode == 9:  # tab key
             event.preventDefault()
-            return
-        doc['code'].value+='\n'
-        history.append(currentLine)
-        current += 1
-        if _status == "main" or _status == "3string":
-            try:
-                _ = exec(currentLine,editor_ns)
-                if _ is not None:
-                    print(repr(_))
-                doc['code'].value += '>>> '
-                _status = "main"
-            except IndentationError:
-                doc['code'].value += '... '
-                _status = "block"
-            except SyntaxError as msg:
-                if str(msg) == 'invalid syntax : triple string end not found' or\
-                    str(msg).startswith('Unbalanced bracket'):
+            doc['code'].value += "    "
+        elif event.keyCode == 13:  # return
+            src = doc['code'].value
+            if _status == "main":
+                currentLine = src[src.rfind('>>>') + 4:]
+            elif _status == "3string":
+                currentLine = src[src.rfind('>>>') + 4:]
+                currentLine = currentLine.replace('\n... ', '\n')
+            else:
+                currentLine = src[src.rfind('...') + 4:]
+            if _status == 'main' and not currentLine.strip():
+                doc['code'].value += '\n>>> '
+                event.preventDefault()
+                return
+            doc['code'].value += '\n'
+            history.append(currentLine)
+            current += 1
+            if _status == "main" or _status == "3string":
+                try:
+                    _ = exec(currentLine, editor_ns)
+                    if _ is not None:
+                        print(repr(_))
+                    doc['code'].value += '>>> '
+                    _status = "main"
+                except IndentationError:
                     doc['code'].value += '... '
-                    _status = "3string"
-                else:
+                    _status = "block"
+                except SyntaxError as msg:
+                    if str(msg) == 'invalid syntax : triple string end not found' or \
+                        str(msg).startswith('Unbalanced bracket'):
+                        doc['code'].value += '... '
+                        _status = "3string"
+                    else:
+                        traceback.print_exc()
+                        doc['code'].value += '>>> '
+                        _status = "main"
+                except:
                     traceback.print_exc()
                     doc['code'].value += '>>> '
                     _status = "main"
-            except:
-                traceback.print_exc()
-                doc['code'].value += '>>> '
+            elif currentLine == "":  # end of block
+                block = src[src.rfind('>>>') + 4:].splitlines()
+                block = [block[0]] + [b[4:] for b in block[1:]]
+                block_src = '\n'.join(block)
+                # status must be set before executing code in globals()
                 _status = "main"
-        elif currentLine == "": # end of block
-            block = src[src.rfind('>>>')+4:].splitlines()
-            block = [block[0]]+[b[4:] for b in block[1:]]
-            block_src = '\n'.join(block)
-            
-            # status must be set before executing code in globals()
-            _status = "main"
-            
-            try:
-                _ = exec(block_src,editor_ns)
-                if _ is not None:
-                    print(repr(_))
-            except:
-                traceback.print_exc()
-            doc['code'].value += '>>> '
-        else:
-            doc['code'].value += '... '        
-        cursorToEnd()
-        event.preventDefault()
-        #event.stopPropagation()
-
-def myKeyDown(event):
-    global _status,current
-    
-    if event.keyCode == 37: # left arrow
-        sel = get_col(doc['code'])
-        if sel<5:
+                try:
+                    _ = exec(block_src, editor_ns)
+                    if _ is not None:
+                        print(repr(_))
+                except:
+                    traceback.print_exc()
+                doc['code'].value += '>>> '
+            else:
+                doc['code'].value += '... '
+            cursorToEnd()
             event.preventDefault()
-            event.stopPropagation()
-    elif event.keyCode == 36: # line start
-        pos = doc['code'].selectionStart
-        col = get_col(doc['code'])
-        doc['code'].setSelectionRange(pos-col+4,pos-col+4)
-        event.preventDefault()
-    elif event.keyCode == 38: # up
-        if current > 0:
+            #event.stopPropagation()
+
+
+    def myKeyDown(event):
+        global _status, current
+        if event.keyCode == 37:  # left arrow
+            sel = get_col(doc['code'])
+            if sel < 5:
+                event.preventDefault()
+                event.stopPropagation()
+        elif event.keyCode == 36:  # line start
             pos = doc['code'].selectionStart
             col = get_col(doc['code'])
-            # remove current line
-            doc['code'].value = doc['code'].value[:pos-col+4]
-            current -= 1
-            doc['code'].value += history[current]
-        event.preventDefault()
-    elif event.keyCode == 40: # down
-        if current < len(history)-1:
-            pos = doc['code'].selectionStart
-            col = get_col(doc['code'])
-            # remove current line
-            doc['code'].value = doc['code'].value[:pos-col+4]
-            current += 1
-            doc['code'].value += history[current]
-        event.preventDefault()
-    elif event.keyCode == 8: # backspace
-        src = doc['code'].value
-        lstart = src.rfind('\n')
-        if (lstart==-1 and len(src)<5) \
-            or (len(src)-lstart<6):
+            doc['code'].setSelectionRange(pos - col + 4, pos - col + 4)
+            event.preventDefault()
+        elif event.keyCode == 38:  # up
+            if current > 0:
+                pos = doc['code'].selectionStart
+                col = get_col(doc['code'])
+                # remove current line
+                doc['code'].value = doc['code'].value[:pos - col + 4]
+                current -= 1
+                doc['code'].value += history[current]
+            event.preventDefault()
+        elif event.keyCode == 40:  # down
+            if current < len(history) - 1:
+                pos = doc['code'].selectionStart
+                col = get_col(doc['code'])
+                # remove current line
+                doc['code'].value = doc['code'].value[:pos - col + 4]
+                current += 1
+                doc['code'].value += history[current]
+            event.preventDefault()
+        elif event.keyCode == 8:  # backspace
+            src = doc['code'].value
+            lstart = src.rfind('\n')
+            if (lstart == -1 and len(src) < 5) or (len(src) - lstart < 6):
                 event.preventDefault()
                 event.stopPropagation()
 
-doc['code'].bind('keypress', myKeyPress)
-doc['code'].bind('keydown', myKeyDown)
-doc['code'].bind('click', cursorToEnd)
-v = sys.implementation.version
-    
-doc['code'].value = "Brython %s.%s.%s on %s %s\n>>> " %(v[0],v[1],v[2],
-    win.navigator.appName,win.navigator.appVersion)
-doc['code'].focus()
-cursorToEnd()
 
-</script>
-<p>The console can be embedded in a web page by adding
-<blockquote>
-<pre>
-&lt;iframe src="http://brython.info/console.html" width=800 height=400&gt;&lt;/iframe&gt;
-</pre></blockquote>
+    doc['code'].bind('keypress', myKeyPress)
+    doc['code'].bind('keydown', myKeyDown)
+    doc['code'].bind('click', cursorToEnd)
+    v = sys.implementation.version
+    doc['code'].value = "Brython %s.%s.%s on %s %s\n>>> " % (
+        v[0], v[1], v[2], win.navigator.appName, win.navigator.appVersion)
+    doc['code'].focus()
+    cursorToEnd()
+    </script>
+
+
+    <details>
+        <summary>Embed:</summary>
+            The console can be embedded in a web page by adding
+        <blockquote>
+            <pre>
+                &lt;iframe src=http://brython.info/console.html width=800 height=400&gt;&lt;/iframe&gt;
+            </pre>
+        </blockquote>
+    </details>
 
 </body>
+
 </html>


### PR DESCRIPTION
- Fix brython.css styles.
- Fix Gallery and Console styles and markup.
- Fix PEP8 / Lint on the Python. 
- Remove unneeded empty trailing white spaces.
- Pages got the same base `<head>` tags.
- No images, just CSS.
- Remove obsolete readme.txt in favor of readme.md

![gallery_styles](https://cloud.githubusercontent.com/assets/1189414/4604435/1e8317d6-519d-11e4-9820-cc98a666e7c8.jpg)

:octocat:
