### PR TITLE
Fix ajax string argument

### DIFF
--- a/src/libs/_ajax.js
+++ b/src/libs/_ajax.js
@@ -24,7 +24,7 @@ $XMLHttpDict.__repr__ = function(self){return '<object XMLHttp>'}
 $XMLHttpDict.__str__ = $XMLHttpDict.toString = $XMLHttpDict.__repr__
 
 $XMLHttpDict.text = function(self){return self.responseText}
-    
+
 $XMLHttpDict.xml = function(self){return $DomObject(self.responseXML)}
 
 $XMLHttpDict.headers = function(self){
@@ -54,10 +54,12 @@ $AjaxDict.open = function(self,method,url,async){
 }
 
 $AjaxDict.send = function(self,params){
-    // params is a Python dictionary
+    // params can be Python dictionary or string
     var res = ''
-    if(!params || params.$keys.length==0){self.$xmlhttp.send();return}
-    else if(isinstance(params,str)){
+    if(!params){
+        self.$xmlhttp.send();
+        return;
+    }else if(isinstance(params,str)){
         res = params
     }else if(isinstance(params,dict)){
         for(i=0;i<params.$keys.length;i++){
@@ -65,7 +67,7 @@ $AjaxDict.send = function(self,params){
         }
         res = res.substr(0,res.length-1)
     }else{
-        throw _b_.TypeError("send() argument must be string or dictonary, not '"+str(params.__class__)+"'")
+        throw _b_.TypeError("send() argument must be string or dictionary, not '"+str(params.__class__)+"'")
     }
     self.$xmlhttp.send(res)
 }
@@ -76,8 +78,8 @@ $AjaxDict.set_header = function(self,key,value){
 
 $AjaxDict.set_timeout = function(self,seconds,func){
     self.$xmlhttp.$requestTimer = setTimeout(
-        function() {self.$xmlhttp.abort();func()}, 
-        seconds*1000); 
+        function() {self.$xmlhttp.abort();func()},
+        seconds*1000);
 }
 
 function ajax(){
@@ -93,7 +95,7 @@ function ajax(){
     }
     $xmlhttp.$requestTimer = null
     $xmlhttp.__class__ = $XMLHttpDict
-    
+
     $xmlhttp.onreadystatechange = function(){
         // here, "this" refers to $xmlhttp
         var state = this.readyState


### PR DESCRIPTION
The ajax.send function fails every time it is called with a string
parameter. This happens because the ‘send’ javascript function tests
for ‘params.$keys.length==0’ before checking if it is a string, and
strings don’t have ‘$keys’.

This change fixes the problem, and continues to work for the empty
dictionary case (when $keys.length==0) which is perfectly handled by
the ‘for’ loop over the length of keys.

(By the way, I spot this error while doing 'req.send(json.dumps(data))', i.e., sending JSON data to the server as string. It now works perfectly!)
