### PR TITLE
Fixed sending arrays using POST method

### DIFF
--- a/src/libs/_ajax.js
+++ b/src/libs/_ajax.js
@@ -63,7 +63,14 @@ $AjaxDict.send = function(self,params){
         res = params
     }else if(isinstance(params,dict)){
         for(var i=0, _len_i = params.$keys.length; i < _len_i;i++){
-            res +=encodeURIComponent(str(params.$keys[i]))+'='+encodeURIComponent(str(params.$values[i]))+'&'
+            var key = encodeURIComponent(str(params.$keys[i]));
+            if (isinstance(params.$values[i],list)) {
+                for (j = 0; j < params.$values[i].length; j++) {
+                    res += key +'=' + encodeURIComponent(str(params.$values[i][j])) + '&'
+                }
+            } else {
+                res += key + '=' + encodeURIComponent(str(params.$values[i])) + '&'
+            }
         }
         res = res.substr(0,res.length-1)
     }else{


### PR DESCRIPTION
Sending an array as one of params dict items through ajax was done in incorrect way. A text representation of list was sent, instead of sending each item under the same (list's) key
