### PR TITLE
Fix bug that causes exponential increase in runtime for formatting of strings with 2 or more {}

### DIFF
--- a/src/py_string.js
+++ b/src/py_string.js
@@ -1103,7 +1103,7 @@ var $FormattableString=function(format_string) {
       '(%)' +
       '|((?!{)(?:{{)+' +
       '|(?:}})+(?!})' +
-      '|{(?:[^{](?:[^{}]+|{[^{}]*})*)?})', 'g'
+      '|{(?:[^{}](?:[^{}]+|{[^{}]*})*)?})', 'g'
     )
 
     this.format_sub_re = new RegExp('({[^{}]*})')  // nested replacement field


### PR DESCRIPTION
This bug causes problems with expressions like:

f = "{} abcdefghijklmnopqrstuvwxyz {}".format("20", "30")

It runs REALLY slow without the  }