### PR TITLE
Temporary hack to fix problems with random module

### DIFF
--- a/src/Lib/_random.py
+++ b/src/Lib/_random.py
@@ -71,4 +71,4 @@ class Random:
             raise TypeError('number of bits should be an integer')
         numbytes = (k + 7) // 8                       # bits / 8 and rounded up
         x = int.from_bytes(_urandom(numbytes), 'big')
-        return x >> (numbytes * 8 - k)                # trim excess bits
+        return x >> (numbytes * 8 - k) - 1                # trim excess bits

--- a/src/Lib/random.py
+++ b/src/Lib/random.py
@@ -46,11 +46,14 @@ from types import MethodType as _MethodType, BuiltinMethodType as _BuiltinMethod
 from math import log as _log, exp as _exp, pi as _pi, e as _e, ceil as _ceil
 from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
 
+import __random
+import _random
+
 #from os import urandom as _urandom
 def _urandom(n):
     """urandom(n) -> str    
     Return n random bytes suitable for cryptographic use."""
-    import __random
+    #import __random
     randbytes= [__random.randint(0,255) for i in range(n)]
     return bytes(randbytes)
     
@@ -79,7 +82,7 @@ RECIP_BPF = 2**-BPF
 # Adrian Baddeley.  Adapted by Raymond Hettinger for use with
 # the Mersenne Twister  and os.urandom() core generators.
 
-import _random
+#import _random
 
 class Random(_random.Random):
     """Random number generator base class used by bound module functions.
@@ -232,10 +235,11 @@ class Random(_random.Random):
                    Method=_MethodType, BuiltinMethod=_BuiltinMethodType):
         "Return a random int in the range [0,n).  Raises ValueError if n==0."
 
+        random = self.random
         getrandbits = self.getrandbits
         # Only call self.getrandbits if the original random() builtin method
         # has not been overridden or if a new getrandbits() was supplied.
-        if type(self.random) is BuiltinMethod or type(getrandbits) is Method:
+        if type(random) is BuiltinMethod or type(getrandbits) is Method:
             k = n.bit_length()  # don't use (n-1) here because n can be 1
             r = getrandbits(k)          # 0 <= r < 2**k
             while r >= n:
@@ -243,7 +247,7 @@ class Random(_random.Random):
             return r
         # There's an overriden random() method but no new getrandbits() method,
         # so we can only use random() from here.
-        random = self.random
+        #random = self.random
         if n >= maxsize:
             _warn("Underlying random() generator does not supply \n"
                 "enough bits to choose from a population range this large.\n"

--- a/src/Lib/random.py
+++ b/src/Lib/random.py
@@ -667,7 +667,7 @@ class SystemRandom(Random):
             raise TypeError('number of bits should be an integer')
         numbytes = (k + 7) // 8                       # bits / 8 and rounded up
         x = int.from_bytes(_urandom(numbytes), 'big')
-        return x >> (numbytes * 8 - k)                # trim excess bits
+        return x >> (numbytes * 8 - k) - 1                # trim excess bits
 
     def seed(self, *args, **kwds):
         "Stub method.  Not used for a system random number generator."


### PR DESCRIPTION
I found some troubles with random module. I think the problems are related with `int.from_bytes` not returning the correct results. And maybe the problems are related with how the python bytes are implemented in Brython.

I found some errors using examples from the official docs:
https://docs.python.org/3/library/stdtypes.html?highlight=from_bytes#int.from_bytes

I checked that all the methods in the ***random*** module the use `getrandbits` are returning coherent values but I didn't created tests as I think the problem should be analysed deeper.