### PR TITLE
Added DeprecationWarning to console.log() in browser module

### DIFF
--- a/src/libs/_browser.js
+++ b/src/libs/_browser.js
@@ -2,7 +2,9 @@ var $module=(function($B) {
   return {
     alert:function(message){window.alert($B.builtins.str(message))},
     confirm: function(message){return $B.JSObject(window.confirm(message))},
-    console:{log:function(data){window.console.log(data)}},
+    console:{log:function(data){window.console.log("DeprecationWarning: console.log() will be deprecated,\n"+
+		                                           "use print() instead.\n");
+		                        window.console.log(data)}},
     document:$B.$DOMNode(document),
     doc: $B.$DOMNode(document),   //want to use document instead of doc
     DOMEvent:$B.DOMEvent,


### PR DESCRIPTION
As `console.log()` is just similar to python `print()` the inclusion of `console` in the `browser` module with the limited funcionality of `log` is redundandt and maybe confuse.

I added a `DeprecationWarning` to warn users to update the code to `print()` and in future releases `console.log` should be removed from `browser`.