### PR TITLE
Change websocket to WebSocket, update documentation

### DIFF
--- a/site/doc/en/websockets.md
+++ b/site/doc/en/websockets.md
@@ -5,7 +5,7 @@ Web sockets, defined in HTML5, are a way to handle bi directional communication 
 
 The module defines one function :
 
-`websocket(`_host_`)`
+`WebSocket(`_host_`)`
 > _host_ is the location of a server that supports the WebSocket protocol. Returns a `WebSocket` object
 
 > If the browser doesn't support WebSocket, a `NotImplementedError` will be raised
@@ -51,7 +51,7 @@ Example :
 <tr>
 <td id="py_source">
     from browser import document as doc
-    from browser import alert,websocket
+    from browser import alert,WebSocket
     
     def on_open(evt):
         doc['sendbtn'].disabled = False
@@ -76,7 +76,7 @@ Example :
             return
         global ws
         # open a web socket
-        ws = websocket.websocket("wss://echo.websocket.org")
+        ws = WebSocket("wss://echo.websocket.org")
         # bind functions to web socket events
         ws.bind('open',on_open)
         ws.bind('message',on_message)

--- a/site/doc/es/websockets.md
+++ b/site/doc/es/websockets.md
@@ -54,7 +54,7 @@ Ejemplo :
 <tr>
 <td id="py_source">
     from browser import document as doc
-    from browser import alert,websocket
+    from browser import alert,WebSocket
     
     def on_open(evt):
         doc['sendbtn'].disabled = False
@@ -79,7 +79,7 @@ Ejemplo :
             return
         global ws
         # open a web socket
-        ws = websocket.websocket("wss://echo.websocket.org")
+        ws = WebSocket("wss://echo.websocket.org")
         # bind functions to web socket events
         ws.bind('open',on_open)
         ws.bind('message',on_message)

--- a/site/doc/fr/websockets.md
+++ b/site/doc/fr/websockets.md
@@ -60,7 +60,7 @@ Exemple :
 <td>
 ```exec_on_load
 from browser import document as doc
-from browser import websocket, alert
+from browser import WebSocket, alert
 
 def on_open(evt):
     doc['sendbtn'].disabled = False
@@ -85,7 +85,7 @@ def _open(ev):
         return
     global ws
     # open a web socket
-    ws = websocket.websocket("wss://echo.websocket.org")
+    ws = WebSocket("wss://echo.websocket.org")
     # attache des fonctions aux événements web sockets
     ws.bind('open',on_open)
     ws.bind('message',on_message)

--- a/site/doc/pt/websockets.md
+++ b/site/doc/pt/websockets.md
@@ -56,7 +56,7 @@ Exemplo:
 <table>
 <tr>
 <td id="py_source">
-    from browser import doc,alert,websocket
+    from browser import doc,alert,WebSocket
     
     def on_open(evt):
         doc['sendbtn'].disabled = False
@@ -81,7 +81,7 @@ Exemplo:
             return
         global ws
         # open a web socket
-        ws = websocket.websocket("wss://echo.websocket.org")
+        ws = WebSocket("wss://echo.websocket.org")
         # bind functions to web socket events
         ws.bind('open',on_open)
         ws.bind('message',on_message)

--- a/src/Lib/browser/__init__.py
+++ b/src/Lib/browser/__init__.py
@@ -6,4 +6,4 @@ from .local_storage import LocalStorage
 from .session_storage import SessionStorage
 from .object_storage import ObjectStorage
 
-websocket = javascript.JSConstructor(window.WebSocket)
+WebSocket = javascript.JSConstructor(window.WebSocket)


### PR DESCRIPTION
Hello,

 I think websocket should be WebSocket, as that matches the JavaScript built-in, and it's in line with PEP naming conventions for making a constructor CamelCase.

 I'm not a fan of CamelCase, but anything that matches existing standards in the browser is a good idea. 