### PR TITLE
remove unnecesary code that adds wrong attributes to DOMNode instances

### DIFF
--- a/src/libs/_html.js
+++ b/src/libs/_html.js
@@ -48,9 +48,6 @@ function makeTagDict(tagName){
                     try{
                         arg = arg.toLowerCase().replace('_','-')
                         self.elt.setAttribute(arg,value)
-                        if(arg=="class"){ // for IE
-                            self.elt.setAttribute("className",value)
-                        }
                     }catch(err){
                         throw _b_.ValueError("can't set attribute "+arg)
                     }

--- a/src/libs/_svg.js
+++ b/src/libs/_svg.js
@@ -70,9 +70,6 @@ function makeTagDict(tagName){
                     try{
                         arg = arg.toLowerCase().replace('_','-')
                         self.elt.setAttributeNS(null,arg,value)
-                        if(arg=="class"){ // for IE
-                            self.elt.setAttribute("className",value)
-                        }
                     }catch(err){
                         throw ValueError("can't set attribute "+arg)
                     }


### PR DESCRIPTION
I think the removed lines are not needed and they include wrong attributes in all browsers.