### PR TITLE
Mobile Web

### DIFF
--- a/site/doc/doc_brython.css
+++ b/site/doc/doc_brython.css
@@ -132,3 +132,32 @@ strong {
   padding:5px
 }
 
+
+
+
+/* Breakpoint for all color devices of < 999px width */
+@media all and (color) and (max-width: 999px) {
+
+    #banner {
+    padding-bottom: 0
+    }
+
+    a.banner:link,a.banner:visited {
+        font-size: 2em;
+        line-height: 4em;
+        padding: 0
+    }
+
+    #console {
+    font-size: 10px
+    }
+
+    #content {
+    padding: 0
+    }
+
+    img.logo, td.logo {
+        display: none
+    }
+
+}

--- a/site/doc/doc_brython.css
+++ b/site/doc/doc_brython.css
@@ -139,7 +139,7 @@ strong {
 @media all and (color) and (max-width: 999px) {
 
     #banner {
-    padding-bottom: 0
+        padding-bottom: 0
     }
 
     a.banner:link,a.banner:visited {
@@ -149,11 +149,11 @@ strong {
     }
 
     #console {
-    font-size: 10px
+        font-size: 10px
     }
 
     #content {
-    padding: 0
+        padding: 0
     }
 
     img.logo, td.logo {


### PR DESCRIPTION
- Add Mobile Breakpoint.
- Header menu now fits Mobile.
- Tested with Android (real devices), see Screenshot.


![brython-mobile-web](https://cloud.githubusercontent.com/assets/1189414/6140528/cc8d54a6-b177-11e4-83c4-087cf8c09bf8.jpg)


:iphone: 