### PR TITLE
Add Chat Room for Brython Users and Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Stories in Ready](https://badge.waffle.io/brython-dev/brython.svg?label=ready&title=Ready)](http://waffle.io/brython-dev/brython)
+[![Stories in Ready](https://badge.waffle.io/brython-dev/brython.svg?label=ready&title=Ready)](http://waffle.io/brython-dev/brython)    [![Join the chat at https://gitter.im/brython-dev/brython](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/brython-dev/brython?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge "Chat with Brython Users and Developers")
 
 
 brython


### PR DESCRIPTION
- Add Chat Room for Brython Users and Developers.
- No Logic touched, No Code changes, just 1 Line diff.
- Admins of Repo are Admins of Chat, which is Free for Open Source, like GitHub, Travis, etc and has IRC Bridge and Mobile App.

**Examples:**
- https://gitter.im/explore/tags/python
- https://gitter.im/django/django

:busts_in_silhouette: