### PR TITLE
Allow import of symbols containing "." (a dot) from js to browser.window...

### DIFF
--- a/www/src/libs/javascript.js
+++ b/www/src/libs/javascript.js
@@ -14,7 +14,7 @@ var $module=(function($B) {
                 throw $B.builtins.TypeError("argument 'names' should be a list, not '"+$B.get_class(names).__name__)
             }else{
                 for(var i=0;i<names.length;i++){
-                    try{window[names[i]]=eval(names[i])}
+                    try{window[names[i].replace(".", "_")]=eval(names[i])}
                     catch(err){throw $B.builtins.NameError("name '"+names[i]+"' not found in script "+script_url)}
                 }
             }


### PR DESCRIPTION
... namespace

By replacing the dot with an underscore.  This allows javascript.load to import symbols such as "jQuery.jqx", which will be available as browser.window.jQuery_jqx.   Or is there perhaps a better way to do this cleanly, without a patch?