### PR TITLE
Update ipy_id option functionality of brython function

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -6957,7 +6957,6 @@ function brython(options){
 			var $elt = $elts[$i];
 			$src += ($elt.innerHTML || $elt.textContent);
 		}
-		console.log($src);
 		try{
 			// Conversion of Python source code to Javascript
 

--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -6948,103 +6948,160 @@ function brython(options){
     
     // Get all scripts with type = text/python or text/python3 and run them
 
-    var first_script = true, module_name
-    for(var $i=0;$i<$elts.length;$i++){
-        var $elt = $elts[$i]
-        if($elt.type=="text/python"||$elt.type==="text/python3"){
+    var first_script = true, module_name;
+    if(options.ipy_id!==undefined){
+		module_name='__main__';
+		var $src = "";
+		$B.$py_module_path[module_name] = $href;
+		for(var $i=0;$i<$elts.length;$i++){
+			var $elt = $elts[$i];
+			$src += ($elt.innerHTML || $elt.textContent);
+		}
+		console.log($src);
+		try{
+			// Conversion of Python source code to Javascript
 
-            if($elt.id){module_name=$elt.id}
-            else if(first_script){module_name='__main__'; first_script=false}
-            else{module_name = '__main__'+$B.UUID()}
-        
-            // Get Python source code
-            var $src = null
-            if($elt.src){ 
-                // format <script type="text/python" src="python_script.py">
-                // get source code by an Ajax call
-                if (window.XMLHttpRequest){// code for IE7+, Firefox, Chrome, Opera, Safari
-                    var $xmlhttp=new XMLHttpRequest();
-                }else{// code for IE6, IE5
-                    var $xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
-                }
-                $xmlhttp.onreadystatechange = function(){
-                    var state = this.readyState
-                    if(state===4){
-                        $src = $xmlhttp.responseText
-                    }
-                }
-                $xmlhttp.open('GET',$elt.src,false)
-                $xmlhttp.send()
-                if($xmlhttp.status != 200){
-                    var msg = "can't open file '"+$elt.src
-                    msg += "': No such file or directory"
-                    console.log(msg)
-                    return
-                }
-                $B.$py_module_path[module_name]=$elt.src
-                var $src_elts = $elt.src.split('/')
-                $src_elts.pop()
-                var $src_path = $src_elts.join('/')
-                if ($B.path.indexOf($src_path) == -1) {
-                    // insert in first position : folder /Lib with built-in modules
-                    // should be the last used when importing scripts
-                    $B.path.splice(0,0,$src_path)
-                }
-            }else{
-                // Get source code inside the script element
-                var $src = ($elt.innerHTML || $elt.textContent)
-                $B.$py_module_path[module_name] = $href
-            }
+			var $root = $B.py2js($src,module_name,module_name,'__builtins__')
+			//earney
+			var $js = $root.to_js()
+			if($B.debug>1) console.log($js)
 
-            try{
-                // Conversion of Python source code to Javascript
+			if ($B.async_enabled) {
+			   $js = $B.execution_object.source_conversion($js) 
+			   
+			   //console.log($js)
+			   eval($js)
+			} else {
+			   // Run resulting Javascript
+			   eval($js)
+			}
+			
+		}catch($err){
+			if($B.debug>1){
+				console.log($err)
+				for(var attr in $err){
+				   console.log(attr+' : ', $err[attr])
+				}
+			}
 
-                var $root = $B.py2js($src,module_name,module_name,'__builtins__')
-                //earney
-                var $js = $root.to_js()
-                if($B.debug>1) console.log($js)
+			// If the error was not caught by the Python runtime, build an
+			// instance of a Python exception
+			if($err.$py_error===undefined){
+				console.log('Javascript error', $err)
+				//console.log($js)
+				//for(var attr in $err){console.log(attr+': '+$err[attr])}
+				$err=_b_.RuntimeError($err+'')
+			}
 
-                if ($B.async_enabled) {
-                   $js = $B.execution_object.source_conversion($js) 
-                   
-                   //console.log($js)
-                   eval($js)
-                } else {
-                   // Run resulting Javascript
-                   eval($js)
-                }
-                
-            }catch($err){
-                if($B.debug>1){
-                    console.log($err)
-                    for(var attr in $err){
-                       console.log(attr+' : ', $err[attr])
-                    }
-                }
+			// Print the error traceback on the standard error stream
+			var $trace = _b_.getattr($err,'info')+'\n'+$err.__name__+
+				': ' +$err.args
+			try{
+				_b_.getattr($B.stderr,'write')($trace)
+			}catch(print_exc_err){
+				console.log($trace)
+			}
+			// Throw the error to stop execution
+			throw $err
+		}
+	}else{
+		for(var $i=0;$i<$elts.length;$i++){
+			var $elt = $elts[$i]
+			if($elt.type=="text/python"||$elt.type==="text/python3"){
 
-                // If the error was not caught by the Python runtime, build an
-                // instance of a Python exception
-                if($err.$py_error===undefined){
-                    console.log('Javascript error', $err)
-                    //console.log($js)
-                    //for(var attr in $err){console.log(attr+': '+$err[attr])}
-                    $err=_b_.RuntimeError($err+'')
-                }
+				if($elt.id){module_name=$elt.id}
+				else if(first_script){module_name='__main__'; first_script=false}
+				else{module_name = '__main__'+$B.UUID()}
+			
+				// Get Python source code
+				var $src = null
+				if($elt.src){ 
+					// format <script type="text/python" src="python_script.py">
+					// get source code by an Ajax call
+					if (window.XMLHttpRequest){// code for IE7+, Firefox, Chrome, Opera, Safari
+						var $xmlhttp=new XMLHttpRequest();
+					}else{// code for IE6, IE5
+						var $xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
+					}
+					$xmlhttp.onreadystatechange = function(){
+						var state = this.readyState
+						if(state===4){
+							$src = $xmlhttp.responseText
+						}
+					}
+					$xmlhttp.open('GET',$elt.src,false)
+					$xmlhttp.send()
+					if($xmlhttp.status != 200){
+						var msg = "can't open file '"+$elt.src
+						msg += "': No such file or directory"
+						console.log(msg)
+						return
+					}
+					$B.$py_module_path[module_name]=$elt.src
+					var $src_elts = $elt.src.split('/')
+					$src_elts.pop()
+					var $src_path = $src_elts.join('/')
+					if ($B.path.indexOf($src_path) == -1) {
+						// insert in first position : folder /Lib with built-in modules
+						// should be the last used when importing scripts
+						$B.path.splice(0,0,$src_path)
+					}
+				}else{
+					// Get source code inside the script element
+					var $src = ($elt.innerHTML || $elt.textContent)
+					$B.$py_module_path[module_name] = $href
+				}
 
-                // Print the error traceback on the standard error stream
-                var $trace = _b_.getattr($err,'info')+'\n'+$err.__name__+
-                    ': ' +$err.args
-                try{
-                    _b_.getattr($B.stderr,'write')($trace)
-                }catch(print_exc_err){
-                    console.log($trace)
-                }
-                // Throw the error to stop execution
-                throw $err
-            }
+				try{
+					// Conversion of Python source code to Javascript
 
-        }
-    }
+					var $root = $B.py2js($src,module_name,module_name,'__builtins__')
+					//earney
+					var $js = $root.to_js()
+					if($B.debug>1) console.log($js)
+
+					if ($B.async_enabled) {
+					   $js = $B.execution_object.source_conversion($js) 
+					   
+					   //console.log($js)
+					   eval($js)
+					} else {
+					   // Run resulting Javascript
+					   eval($js)
+					}
+					
+				}catch($err){
+					if($B.debug>1){
+						console.log($err)
+						for(var attr in $err){
+						   console.log(attr+' : ', $err[attr])
+						}
+					}
+
+					// If the error was not caught by the Python runtime, build an
+					// instance of a Python exception
+					if($err.$py_error===undefined){
+						console.log('Javascript error', $err)
+						//console.log($js)
+						//for(var attr in $err){console.log(attr+': '+$err[attr])}
+						$err=_b_.RuntimeError($err+'')
+					}
+
+					// Print the error traceback on the standard error stream
+					var $trace = _b_.getattr($err,'info')+'\n'+$err.__name__+
+						': ' +$err.args
+					try{
+						_b_.getattr($B.stderr,'write')($trace)
+					}catch(print_exc_err){
+						console.log($trace)
+					}
+					// Throw the error to stop execution
+					throw $err
+				}
+
+			}
+		}
+	}
 
     /* Uncomment to check the names added in global Javascript namespace
     var kk1 = Object.keys(window)


### PR DESCRIPTION
I updated the `ipy_id` option in the `brython` function in order to maintain the original functionality of the option (i.e., run brython inside the IPython notebook, see https://github.com/kikocorreoso/brythonmagic for more info).

Now it takes all the scripts with their `id` included in the `ipy_id` array and add the code of all of them to be included in the  `__main__` module.