### PR TITLE
Performance improvement for new type creation

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -35,9 +35,9 @@ $B.$class_constructor = function(class_name,class_obj,parents,parents_names,kwar
         __bases__ : bases,
         __dict__ : cl_dict
     }
- 
+
     // set class attributes for faster lookups
-    var items = _b_.list(_b_.dict.$dict.items(cl_dict))
+    var items = $B.$dict_items(cl_dict);
     for(var i=0;i<items.length;i++){
         class_dict[items[i][0]] = items[i][1]
     }
@@ -278,9 +278,9 @@ $B.$type.__new__ = function(cls, name, bases, cl_dict){
         __dict__ : cl_dict,
         $methods : {}
     }
- 
+
     // set class attributes for faster lookups
-    var items = _b_.list(_b_.dict.$dict.items(cl_dict))
+    var items = $B.$dict_items(cl_dict);
     for(var i=0;i<items.length;i++){
         var name=items[i][0], v=items[i][1]
         class_dict[name] = v


### PR DESCRIPTION
This minor tweak significantly speeds up type creation when creating types with a particularly large class dict.

It causes my own .js module to load in less than one second instead of ~2.6 seconds.