### PR TITLE
Entering new line in console should set history cursor to end

### DIFF
--- a/www/tests/console.py
+++ b/www/tests/console.py
@@ -111,7 +111,7 @@ def myKeyPress(event):
             return
         doc['code'].value += '\n'
         history.append(currentLine)
-        current += 1
+        current = len(history)
         if _status == "main" or _status == "3string":
             try:
                 _ = editor_ns['_'] = eval(currentLine, editor_ns)


### PR DESCRIPTION
This fixes some annoying up-arrow behaviour in the console; pressing the up arrow to select a previously entered command would cause the history cursor not to be reset to the end.  This change makes it behave the same way as it does in the CPython console.