### PR TITLE
changed the input function

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -704,7 +704,18 @@ function __import__(mod_name, globals, locals, fromlist, level) {
 }
 
 //not a direct alias of prompt: input has no default value
-function input(src) {return prompt(src)}
+function input(src) {
+    var stdin = ($B.imported.sys && $B.imported.sys.stdin || $B.stdin);
+    // $B.stdout.write(src); // uncomment if we are to mimic the behavior in the console
+    if (stdin.__original__) { return prompt(src); }
+    var val = _b_.getattr(stdin, 'readline')();
+    val = val.split('\n')[0];
+    if (stdin.len === stdin.pos){
+        _b_.getattr(stdin, 'close')();
+    }
+    // $B.stdout.write(val+'\n'); // uncomment if we are to mimic the behavior in the console
+    return val;
+}
 
 function isinstance(obj,arg){
     if(obj===null) return arg===None

--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -602,9 +602,16 @@ $B.stdout = {
 }
 
 $B.stdin = {
-    __class__:$io,
-    //fix me
-    read: function(size){return ''}
+    __class__: $io,
+    __original__:true,
+    closed: false,
+    len:1, pos:0,
+    read: function () {
+        return '';
+    },
+    readline: function() {
+        return '';
+    }
 }
 
 $B.jsobject2pyobject=function(obj){


### PR DESCRIPTION
 to better reflect the behavior in the python3 terminal

where stdin can be replaced by a StringIO class and not thus not prompting the user for input

an example use case

    import io
    import sys

    in_stream = io.StringIO("1\n2\n3")
    sys.stdin = in_stream
    while (not in_stream.closed):
        print(input())
        if in_stream.len==in_stream.pos:
            in_stream.close()
    in_stream.readline() # will throw an I/O error
    sys.stdin = sys.__stdin__
    input() # will prompt normally if we manage to reach it
