### PR TITLE
added port option to server.py script

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,6 +10,18 @@ served from subdirectory cgi-bin
 import os
 import sys
 from webbrowser import open_new_tab
+import argparse
+
+# port to be used when the server runs locally
+parser = argparse.ArgumentParser()
+parser.add_argument('--port', 
+    help="The port to be used by the local server")
+args = parser.parse_args()
+
+if args.port:
+    port = int(args.port)
+else:
+    port = 8000
 
 # generate static doc pages if not already present
 if not os.path.exists(os.path.join(os.getcwd(),'www','static_doc')):
@@ -40,7 +52,7 @@ class RequestHandler(CGIHTTPRequestHandler):
             return os.path.join(cgi_dir,*elts[2:])
         return CGIHTTPRequestHandler.translate_path(self, path)
 
-server_address, handler = ('', 8000), RequestHandler
+server_address, handler = ('', port), RequestHandler
 httpd = server.HTTPServer(server_address, handler)
 print(__doc__)
 print(("Server running on port http://localhost:{}.".format(server_address[1])))

--- a/www/doc/en/dev_env.md
+++ b/www/doc/en/dev_env.md
@@ -10,8 +10,8 @@ A web server is necessary to test the scripts locally while developing. Any web
 server that can serve files with the brython_directory/www as document root will 
 work ; you can use the built-in web server provided in the distribution : open 
 a console window, go to the directory, and run `python server.py`. This will 
-start the server on port 8000 (if you want to use other port number you can use, 
-for instance, `python server.py --port 8001` to use port 8001).
+start the server on port 8000 (if you want to use a different port number you can use
+`python server.py --port 8001` to use port 8001).
 
 Once the server is started, point your web browser to _http://localhost:8000/_ :
 the same page as the [Brython site homepage](http://www.brython.info) should

--- a/www/doc/en/dev_env.md
+++ b/www/doc/en/dev_env.md
@@ -10,7 +10,8 @@ A web server is necessary to test the scripts locally while developing. Any web
 server that can serve files with the brython_directory/www as document root will 
 work ; you can use the built-in web server provided in the distribution : open 
 a console window, go to the directory, and run `python server.py`. This will 
-start the server on port 8000 (edit _server.py_ to change the port number).
+start the server on port 8000 (if you want to use other port number you can use, 
+for instance, `python server.py --port 8001` to use port 8001).
 
 Once the server is started, point your web browser to _http://localhost:8000/_ :
 the same page as the [Brython site homepage](http://www.brython.info) should


### PR DESCRIPTION
I added a port option to the command line in order to run `server.py` on other ports different than 8000 without the need to hard code `server.py`.