### PR TITLE
gallery/pygame/chimp.html: Fix brython.js 404 (but still no pygame)

### DIFF
--- a/www/gallery/pygame/chimp.html
+++ b/www/gallery/pygame/chimp.html
@@ -2,8 +2,8 @@
 
 <head>
 
-<script type="text/javascript" src="external/brython/brython.js"></script>
-<script type="text/javascript" src="external/brython/py_VFS.js"></script>
+<script type="text/javascript" src="../../src/brython.js"></script>
+<script type="text/javascript" src="../../src/py_VFS.js"></script>
 
 <script type="text/python">
 #!/usr/bin/env python


### PR DESCRIPTION
Still doesn't work, site-packages/pygame was removed in 51446c31232c17e1e7471b3064bfc1d352423510; I presume it never really worked?
But at least it won't work for the right reason :-)

Before: http://brython.info/gallery/pygame/chimp.html
After:
https://rawgit.com/cben/brython/patch-1/www/gallery/pygame/chimp.html