### PR TITLE
improvements to method as_integer_ratio to make it more CPython compl…

### DIFF
--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -17,14 +17,40 @@ var $FloatDict = {__class__:$B.$type,
     $native:true}
 
 $FloatDict.as_integer_ratio=function(self) {
-   if (Math.round(self.valueOf()) == self.valueOf()){
-       return _b_.tuple([_b_.int(self.valueOf()), _b_.int(1)])
-   }
-   var _temp=self.valueOf()
-   var i=10
-   while (!(Math.round(_temp/i) == _temp/i)) i*=10
+    if (self.valueOf() == Number.POSITIVE_INFINITY || 
+        self.valueOf() == Number.NEGATIVE_INFINITY){
+        throw _b_.OverflowError("Cannot pass infinity to float.as_integer_ratio.")
+    }
+    if (!Number.isFinite(self.valueOf())){
+        throw _b_.ValueError("Cannot pass NaN to float.as_integer_ratio.")
+    }
+    
+    var tmp = _b_.$frexp(self.valueOf())
+    var fp = tmp[0]
+    var exponent = tmp[1]
+    
+    for (var i = 0; i < 300; i++){
+        if (fp == Math.floor(fp)){
+            break
+        } else {
+            fp *= 2
+            exponent--
+        }
+    }
+    
+    numerator = float(fp)
+    py_exponent = abs(exponent)
+    denominator = 1
+    console.log(exponent, py_exponent, numerator, denominator)
+    py_exponent = _b_.getattr(int(denominator),"__lshift__")(py_exponent)
+    if (exponent > 0){
+        numerator = numerator * py_exponent
+    } else {
+        denominator = py_exponent
+    }
+    console.log(exponent, py_exponent, numerator, denominator)
 
-   return _b_.tuple([_b_.int(_temp*i), _b_.int(i)])
+    return _b_.tuple([_b_.int(numerator), _b_.int(denominator)])
 }
 
 $FloatDict.__bool__ = function(self){return _b_.bool(self.valueOf())}


### PR DESCRIPTION
Improvements to `float` method `as_integer_ratio` to make it more CPython compliant.

* The actual implementation doesn't raise an `OverflowError` when an `inf` is used.
* The actual implementation doesn't raise a `ValueError` when a `NaN` is used.
* The actual implementation returns `NaN NaN` in most of the cases (when it is not a `LongInt`??).

This PR tries to address first and second issue and an incomplete solution to third issue (issues stated above).

The following code:

```python
numbers = [-0.1, 
           1.1112, 
           2345.123456789, 
           9048573849586749.443,
           123456789012345678901234567890.123456789]

for number in numbers:
    a, b = number.as_integer_ratio()
    print(a,b)
```

returns:
```python
# CPython 3.4.3 on Win7
-3602879701896397 36028797018963968
5004399905934095 4503599627370496
5156981018619507 2199023255552
9048573849586750 1
123456789012345677877719597056 1
```

```python
# Brython 3.2.3 on Win7 and FF 43.0.1 (dev. edition)
NaN NaN # wrong
NaN NaN # wrong
NaN NaN # wrong
9048573849586750 1
1 1 # wrong
```

```python
# Brython modified with code in this PR on Win7 and FF 43.0.1 (dev. edition)
-3602879701896397 36028797018963968
5004399905934095 4503599627370496
5156981018619507 2199023255552
9048573849586750 1
1 1 # wrong
```

My implementation is based on my understanding of the [official *floatobject.c* in CPython3](https://hg.python.org/cpython/file/default/Objects/floatobject.c#l1447) but I don't know the C CPython internals and it could be wrong as I could misunderstand something.

@PierreQuentel, could you have a look?

Thanks and happy new year to everyone.