### PR TITLE
fix JSObject function wrapping

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -385,7 +385,7 @@ function JSObject(obj){
     // If obj is a function, calling it with JSObject implies that it is
     // a function defined in Javascript. It must be wrapped in a JSObject
     // so that when called, the arguments are transformed into JS values
-    if(typeof obj=='function'){return {__class__:$JSObjectDict,js:obj}}
+    if(typeof obj=='function'){return {__class__:$JSObjectDict,js:obj,js_func:obj}}
 
     var klass = $B.get_class(obj)
     // we need to do this or nan is returned, when doing json.loads(...)


### PR DESCRIPTION
Set js_func on JSObject if it wraps function

This fixes errors when JSObject-wrapped function was fed into JSConstructor
and no js_func was present.

I couldn't find any contribution guides and where to put tests, so i'll provide a simple test here to illustrate the issue:

```
<!DOCTYPE html>
<html>
<head>
<meta charset="UTF-8">
<script src="/brython.js"></script>
</head>
<body onload="brython()">
<script type="text/javascript">
window.get_constructor = function() {
    return function() {
        this.foo = 'hi';
    };
}
</script>
<script type="text/python">
from browser import window
from javascript import JSConstructor

Foo = JSConstructor(window.get_constructor())
print(Foo().foo)
</script>
</body>
</html>
```