### PR TITLE
added condition to avoid a nasty error on brythonmagic

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -7679,7 +7679,7 @@ function brython(options){
     
     // Option to run code on demand and not all the scripts defined in a page
     // The following lines are included to allow to run brython scripts in
-    // the IPython notebook using a cell magic. Have a look at
+    // the IPython/Jupyter notebook using a cell magic. Have a look at
     // https://github.com/kikocorreoso/brythonmagic for more info.
     if(options.ipy_id!==undefined){
        var $elts = [];
@@ -7851,7 +7851,7 @@ function brython(options){
         run_script(inner_scripts[i])
     }
     */
-    $B._load_scripts(scripts)
+    if (options.ipy_id === undefined){$B._load_scripts(scripts)}
 
     /* Uncomment to check the names added in global Javascript namespace
     var kk1 = Object.keys(window)


### PR DESCRIPTION
`loading_scripts` function was adding a nasty error when the option `ipy_id` is used in the `brython` function options. This PR should fix this issue.