### PR TITLE
fix some bad behaviour with webbrowser.py module

### DIFF
--- a/www/src/Lib/webbrowser.py
+++ b/www/src/Lib/webbrowser.py
@@ -13,6 +13,17 @@ def open(url, new=0, autoraise=True):
     new window or tab is not controllable
     on the client side. autoraise not available.
     """
+    # javascript window.open doesn't work if you do not specify the protocol
+    # A solution is the next hack:
+    if '://' in url:
+        if url[:6] == 'ftp://':
+            print('entro')
+        else:
+            protocol = url.split('//:')[0]
+            url = url.replace(protocol + '//:', '//')
+    else:
+        url = '//' + url
+    print(url)
     if window.open(url, _target[new]):
 		return True
     return False


### PR DESCRIPTION
Fix to improve the behaviour of `webbrowser.open` and friends. In CPython, the following works:

````python
import webbrowser as wb

wb.open('osm.org') #http
wb.open('www.osm.org') #http
wb.open('ftp://ftp.swfwmd.state.fl.us/pub/') #ftp with protocol
wb.open('ftp.swfwmd.state.fl.us/pub/') #ftp without protocol
wb.open('gmail.com') #https
```

In Brython only the third option is working as it is included the protocol (*ftp://*) in the url.

This PR tries to fix this.