### PR TITLE
New option server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -14,8 +14,16 @@ import argparse
 
 # port to be used when the server runs locally
 parser = argparse.ArgumentParser()
-parser.add_argument('--port', 
-    help="The port to be used by the local server")
+parser.add_argument('--port', help="The port to be used by the local server")
+
+# generate docs?
+# when testing new code on your repo it is not necessary to generate docs all
+# the time so this option allows you to avoid this process
+parser.add_argument(
+    '--no-docs', 
+    help="Do not generate static docs.", 
+    action="store_true")
+
 args = parser.parse_args()
 
 if args.port:
@@ -23,14 +31,15 @@ if args.port:
 else:
     port = 8000
 
-# generate static doc pages if not already present
-if not os.path.exists(os.path.join(os.getcwd(),'www','static_doc')):
-    save_dir = os.getcwd()
-    os.chdir(os.path.join(os.getcwd(),'scripts'))
-    make_doc = open('make_doc.py', "rb").read()
-    make_doc = make_doc.decode("utf-8")
-    exec(make_doc)
-    os.chdir(save_dir)
+if not args.no_docs:
+    # generate static doc pages if not already present
+    if not os.path.exists(os.path.join(os.getcwd(),'www','static_doc')):
+        save_dir = os.getcwd()
+        os.chdir(os.path.join(os.getcwd(),'scripts'))
+        make_doc = open('make_doc.py', "rb").read()
+        make_doc = make_doc.decode("utf-8")
+        exec(make_doc)
+        os.chdir(save_dir)
 
 os.chdir(os.path.join(os.getcwd(), 'www'))
 

--- a/www/doc/en/dev_env.md
+++ b/www/doc/en/dev_env.md
@@ -10,10 +10,19 @@ A web server is necessary to test the scripts locally while developing. Any web
 server that can serve files with the brython_directory/www as document root will 
 work ; you can use the built-in web server provided in the distribution : open 
 a console window, go to the directory, and run `python server.py`. This will 
-start the server on port 8000 (if you want to use a different port number you can use
-`python server.py --port 8001` to use port 8001).
+start the server on port 8000 and it will create the 
+*static_doc* folder. Options for the *server.py* script:
 
-Once the server is started, point your web browser to _http://localhost:8000/_ :
+* `--port <int>`: if you want to use a different port number you can use
+`python server.py --port 8001` to use port 8001).
+* `--no-docs`: when you are testing stuff sometimes it is no necessary to create
+the *static_doc* folder. If you want to avoid this step you can do 
+`python server.py --no-docs`. WARNING: If you use this option then the docs will
+not be available in your localhost.
+
+Once the server is started, point your web browser to _http://localhost:8000/_ 
+(or http://localhost:<port> if you used the option 
+`python server.py --port <port>`):
 the same page as the [Brython site homepage](http://www.brython.info) should
 appear.
 

--- a/www/doc/es/dev_env.md
+++ b/www/doc/es/dev_env.md
@@ -1,13 +1,36 @@
 Entorno de desarrollo
 ---------------------
 
-Los desarrolladores deberían usar el entorno de desarrollo disponible para descarga en [downloads](https://github.com/brython-dev/brython/releases) : elige el fichero zip cuyo nombre comienza por "BrythonX.Y.Z_site_mirror" donde X.Y.Z es el número de versión y descomprímelo en una carpeta (la llamaremos la carpeta Brython  en los siguientes párrafos).
+Los desarrolladores deberían usar el entorno de desarrollo disponible para 
+descarga en [downloads](https://github.com/brython-dev/brython/releases) : 
+elige el fichero zip cuyo nombre comienza por "BrythonX.Y.Z_site_mirror" donde 
+X.Y.Z es el número de versión y descomprímelo en una carpeta (la llamaremos la 
+carpeta Brython  en los siguientes párrafos).
 
-Es necesario un servidor web para poder probar los scripts localmente mientras nos encontramos desarrollando. Cualquier servidor web que sea capaz de servir ficheros con la carpeta *brython_directory/www* como documento raíz es válido ; puedes usar el servidor incluido con la distribución : abre una consola, muévete hasta la carpeta donde se encuentra el fichero server.py y ejecuta `python server.py`. Esto arrancará un servidor en el puerto 8000 (para usar un puerto diferente puedes usar el siguiente código para usar el puerto 8001 `python server.py --port 8001`).
+Es necesario un servidor web para poder probar los scripts localmente mientras 
+nos encontramos desarrollando. Cualquier servidor web que sea capaz de servir 
+ficheros con la carpeta *brython_directory/www* como documento raíz es válido ; 
+puedes usar el servidor incluido con la distribución : abre una consola, muévete 
+hasta la carpeta donde se encuentra el fichero server.py y ejecuta 
+`python server.py`. Esto arrancará un servidor en el puerto 8000 y creará una 
+carpeta *static_doc*. Opciones para el script *server.py*:
 
-Una vez que el servidor ha arrancado, apunta tu navegador a _http://localhost:8000/site_ : deberías poder ver la misma página que en [la página de inicio oficial de Brython](http://www.brython.info)
+* `--port <int>`: si deseas usar un puerto diferente puedes usar esta opción.
+Por ejemplo, `python server.py --port 8001` para usar el puerto 8001.
+* `--no-docs`: cuando estás haciendo pruebas no siempre es necesario crear la
+carpeta *static_doc*. Si quieres evitar este paso lo puedes hacer usando 
+`python server.py --no-docs`. AVISO: Si usas esta opción la documentación no
+estará disponible en el localhost.
 
-Crea una nueva carpeta (eg "whatever") en la carpeta *brython_directory/www*. Con un editor de texto crea un fichero llamado __index.html__ con el contenido mostrado más abajo y guárdalo en la carpeta *brython_directory/www/whatever/index.html*
+Una vez que el servidor ha arrancado, apunta tu navegador a 
+_http://localhost:8000/site_ (o http://localhost:<port> si usaste la opción 
+`python server.py --port <port>`): deberías poder ver la misma página que en 
+[la página de inicio oficial de Brython](http://www.brython.info)
+
+Crea una nueva carpeta (eg "whatever") en la carpeta *brython_directory/www*. 
+Con un editor de texto crea un fichero llamado __index.html__ con el contenido 
+mostrado más abajo y guárdalo en la carpeta 
+*brython_directory/www/whatever/index.html*
 
 >    <html>
 >    <head>
@@ -28,6 +51,9 @@ Crea una nueva carpeta (eg "whatever") en la carpeta *brython_directory/www*. Co
 >    </body>
 >    </html>
 
-Apunta el navegador hacia *http://localhost:8000/whatever/index.html * : bingo ! Acabas de escribir tu primera aplicación Brython.
+Apunta el navegador hacia *http://localhost:8000/whatever/index.html * : bingo ! 
+Acabas de escribir tu primera aplicación Brython.
 
-Usa este entorno para pruebas y desarrollo. Solo debes acordarte de apuntar el script _brython.js_ a la localización correcta en relación a la carpeta donde se encuentran las páginas HTML que lo usen.
+Usa este entorno para pruebas y desarrollo. Solo debes acordarte de apuntar el 
+script _brython.js_ a la localización correcta en relación a la carpeta donde se 
+encuentran las páginas HTML que lo usen.


### PR DESCRIPTION
Sometimes, when you are developing with brython you start the development environment from you own clone and to  have to create the static docs every time if they are not present could be tedious because is slower and you have new untracked files in your repo..

I added the option `--no-docs` to *server.py* to slightly improve the developer experience.

I also added some info on the docs in the EN and ES versions. **The FR docs should be fixed**.