### PR TITLE
fix issue with absolute value of complex numbers

### DIFF
--- a/www/src/py_complex.js
+++ b/www/src/py_complex.js
@@ -15,7 +15,7 @@ var $ComplexDict = {__class__:$B.$type,
     descriptors:{real:true, imag:true}
 }
 
-$ComplexDict.__abs__ = function(self,other){return complex(abs(self.real),abs(self.imag))}
+$ComplexDict.__abs__ = function(self){return Math.sqrt(Math.pow(self.real,2)+Math.pow(self.imag,2))}
 
 $ComplexDict.__bool__ = function(self){return new Boolean(self.real || self.imag)}
 

--- a/www/tests/test_numbers.py
+++ b/www/tests/test_numbers.py
@@ -55,6 +55,9 @@ assert 3*a == 12+6j
 assert 1.0+a == 5+2j
 assert 2.0-a == -2-2j
 assert 3.0*a == 12+6j
+assert abs(3 + 4j) == 5
+assert abs(4 + 3j) == 5.0
+assert abs(4 + 3j) == abs(3 + 4j)
 
 assert hash(1.0) == 1
 


### PR DESCRIPTION
In CPython:

`print(abs(3+4j))`

returns

`5.0`

In Brython it was returning the absolute value of the real and imaginary parts.