### PR TITLE
deployment should always be over https

### DIFF
--- a/www/doc/en/deploy.md
+++ b/www/doc/en/deploy.md
@@ -12,6 +12,6 @@ Deploying without installing
 
 An even more straightforward solution is to install nothing on the server, but to call all the Python environment from the site brython.info :
 
-    <script src="http://brython.info/src/brython_dist.js"></script>
+    <script src="https://brython.info/src/brython_dist.js"></script>
 
 The drawback of this method is the relatively important size of the distribution, which includes the standard library


### PR DESCRIPTION
Change the URL used for deployment to an HTTPS URL.