### PR TITLE
Fix #467 Incorrect message in SyntaxError

### DIFF
--- a/www/src/brython.js
+++ b/www/src/brython.js
@@ -3228,8 +3228,10 @@ switch(C.expect){case ',':
 case 'eol':
 C.bind_names()
 return $transition(C.parent,token)
+case 'id':
+$_SyntaxError(C,['trailing comma not allowed without surrounding parentheses'])
 default:
-$_SyntaxError(C,['trailing comma not allowed without surrounding parentheses'])}
+$_SyntaxError(C,['invalid syntax'])}
 case 'as':
 if(C.expect==',' ||C.expect=='eol'){C.expect='alias'
 return C}

--- a/www/src/brython_dist.js
+++ b/www/src/brython_dist.js
@@ -3228,8 +3228,10 @@ switch(C.expect){case ',':
 case 'eol':
 C.bind_names()
 return $transition(C.parent,token)
+case 'id':
+$_SyntaxError(C,['trailing comma not allowed without surrounding parentheses'])
 default:
-$_SyntaxError(C,['trailing comma not allowed without surrounding parentheses'])}
+$_SyntaxError(C,['invalid syntax'])}
 case 'as':
 if(C.expect==',' ||C.expect=='eol'){C.expect='alias'
 return C}

--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -6145,8 +6145,10 @@ function $transition(context,token){
               case 'eol':
                 context.bind_names()
                 return $transition(context.parent,token)
-              default:
+              case 'id':
                 $_SyntaxError(context,['trailing comma not allowed without surrounding parentheses'])
+              default:
+                $_SyntaxError(context,['invalid syntax'])
             }
           case 'as':
             if (context.expect ==',' || context.expect=='eol'){


### PR DESCRIPTION
The line `from` used to generate the incorrect error:

```
SyntaxError: trailing comma not allowed without surrounding parentheses
```

This commit keeps this error for import with a trailing space like `from math
import pi,` but uses the generic error message `syntax error` for the rest.