### PR TITLE
Fix import of pydoc

### DIFF
--- a/www/src/Lib/importlib/__init__.py
+++ b/www/src/Lib/importlib/__init__.py
@@ -12,7 +12,7 @@ __all__ = ['__import__', 'import_module', 'invalidate_caches']
 import _imp  # Just the builtin component, NOT the full Python module
 import sys
 
-from . import machinery   #fix me brython
+from . import machinery
 
 try:
     import _frozen_importlib as _bootstrap

--- a/www/src/Lib/importlib/_bootstrap.py
+++ b/www/src/Lib/importlib/_bootstrap.py
@@ -1653,7 +1653,7 @@ def _get_supported_file_loaders():
     return [extensions, source, bytecode]
 
 
-def __import__(name, globals=None, locals=None, fromlist=(), level=0):
+def __import__(name, globals=None, locals=None, fromlist=(), level=0, blocking=True):
     """Import a module.
 
     The 'globals' argument is used to infer where the import is occuring from

--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -7555,8 +7555,8 @@ $B.py2js = function(src, module, locals_id, parent_block_id, line_info){
     root.insert(offset++,file_node)
 
     var enter_frame_pos = offset
-    root.insert(offset++, $NodeJS('$B.enter_frame(["'+locals_id+'", '+local_ns+','+
-        '"'+module+'", '+global_ns+']);\n'))
+    root.insert(offset++, $NodeJS('$B.enter_frame(["'+locals_id.replace(/\./g,'_')+'", '+local_ns+','+
+        '"'+module.replace(/\./g,'_')+'", '+global_ns+', "a"]);\n'))
 
     // Wrap code in a try/finally to make sure we leave the frame
     var try_node = new $Node(),


### PR DESCRIPTION
Those two commits fix `import pydoc`. That might prove useful to get `help()` back!