### PR TITLE
BUGFIX: Fix formating precision for floats close to 0 (Issue #486)

### DIFF
--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -172,17 +172,11 @@ function preformat(self, fmt){
     }
     
     if(fmt.precision!==undefined){
-        // Use Javascript toPrecision to get the correct result
-        // The argument of toPrecision is the number of digits after .
-        // For format type f, precision is the total number of digits, so we
-        // must add the number of digits before "."
+        // Use Javascript toFixed to get the correct result
+        // The argument of toFixed is the number of digits after .
         var prec = fmt.precision
         if(prec==0){return Math.round(self)+''}
-        if(prec && 'fF%'.indexOf(fmt.type)>-1){
-            var pos_pt = Math.abs(self).toString().search(/\./)
-            if(pos_pt>-1){prec+=pos_pt}else{prec=Math.abs(self).toString().length}
-        }
-        var res = self.toPrecision(prec),
+        var res = self.toFixed(prec),
             pt_pos=res.indexOf('.')
         if(fmt.type!==undefined && 
             (fmt.type=='%' || fmt.type.toLowerCase()=='f')){


### PR DESCRIPTION
The `toPrecision` function prints precision number of **significant** digits instead of **number of digits after the decimal point**:

https://developer.mozilla.org/cs/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision)

For numbers which are close to 0 (closer than (10**-precision)) this is wrong. We should call `toFixed` instead.

This fixes Issue #486 