### PR TITLE
Implement a ConsoleHandler for the logging module

### DIFF
--- a/www/src/Lib/logging/__init__.py
+++ b/www/src/Lib/logging/__init__.py
@@ -25,11 +25,12 @@ To use, simply 'import logging' and log away!
 
 import sys, os, time, io, traceback, warnings, weakref
 from string import Template
+from browser import console
 
 __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
            'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
            'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
-           'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
+           'StreamHandler', 'ConsoleHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
            'captureWarnings', 'critical', 'debug', 'disable', 'error',
            'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
            'info', 'log', 'makeLogRecord', 'setLoggerClass', 'warn', 'warning',
@@ -1016,7 +1017,30 @@ class _StderrHandler(StreamHandler):
         return sys.stderr
 
 
-_defaultLastResort = _StderrHandler(WARNING)
+class ConsoleHandler(Handler):
+    """
+    A handler class which writes logging records, appropriately formatted,
+    to the browser console.
+    """
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        If a formatter is specified, it is used to format the record.
+        The record is then written to the stream with a trailing newline.  If
+        exception information is present, it is formatted using
+        traceback.print_exception and appended to the stream.  If the stream
+        has an 'encoding' attribute, it is used to determine how to do the
+        output to the stream.
+        """
+        try:
+            msg = self.format(record)
+            console.log(msg)
+        except:
+            self.handleError(record)
+
+_defaultLastResort = ConsoleHandler(WARNING)
 lastResort = _defaultLastResort
 
 #---------------------------------------------------------------------------
@@ -1700,7 +1724,10 @@ def basicConfig(**kwargs):
                     h = FileHandler(filename, mode)
                 else:
                     stream = kwargs.get("stream")
-                    h = StreamHandler(stream)
+                    if stream:
+                        h = StreamHandler(stream)
+                    else:
+                        h = ConsoleHandler()
                 handlers = [h]
             fs = kwargs.get("format", BASIC_FORMAT)
             dfs = kwargs.get("datefmt", None)

--- a/www/src/Lib/logging/__init__.py
+++ b/www/src/Lib/logging/__init__.py
@@ -1020,7 +1020,7 @@ class _StderrHandler(StreamHandler):
 class ConsoleHandler(Handler):
     """
     A handler class which writes logging records, appropriately formatted,
-    to the browser console.
+    to the browser's debug console.
     """
 
     def emit(self, record):
@@ -1028,11 +1028,9 @@ class ConsoleHandler(Handler):
         Emit a record.
 
         If a formatter is specified, it is used to format the record.
-        The record is then written to the stream with a trailing newline.  If
-        exception information is present, it is formatted using
-        traceback.print_exception and appended to the stream.  If the stream
-        has an 'encoding' attribute, it is used to determine how to do the
-        output to the stream.
+        The record is then written to the browser's debug console.
+        If exception information is present, it is formatted using
+        traceback.print_exception and appended to the console.
         """
         try:
             msg = self.format(record)

--- a/www/src/Lib/logging/__init__.py
+++ b/www/src/Lib/logging/__init__.py
@@ -502,7 +502,7 @@ class Formatter(object):
         # See issues #9427, #1553375. Commented out for now.
         #if getattr(self, 'fullstack', False):
         #    traceback.print_stack(tb.tb_frame.f_back, file=sio)
-        traceback.print_exception(ei[0], ei[1], tb, None, sio)
+        traceback.print_exc(file=sio)
         s = sio.getvalue()
         sio.close()
         if s[-1:] == "\n":
@@ -881,16 +881,12 @@ class Handler(Filterer):
         The record which was being processed is passed in to this method.
         """
         if raiseExceptions and sys.stderr:  # see issue 13807
-            ei = sys.exc_info()
             try:
-                traceback.print_exception(ei[0], ei[1], ei[2],
-                                          None, sys.stderr)
+                traceback.print_exc(file=sys.stderr)
                 sys.stderr.write('Logged from file %s, line %s\n' % (
                                  record.filename, record.lineno))
             except IOError: #pragma: no cover
                 pass    # see issue 5971
-            finally:
-                del ei
 
 class StreamHandler(Handler):
     """

--- a/www/src/Lib/logging/brython_handlers.py
+++ b/www/src/Lib/logging/brython_handlers.py
@@ -1,0 +1,41 @@
+import logging
+
+from browser.ajax import ajax
+
+
+class XMLHTTPHandler(logging.Handler):
+    """
+    A class which sends records to a Web server, using either GET or
+    POST semantics.
+    """
+    def __init__(self, url, method="GET"):
+        """
+        Initialize the instance with the host, the request URL, and the method
+        ("GET" or "POST")
+        """
+        logging.Handler.__init__(self)
+        method = method.upper()
+        if method not in ["GET", "POST"]:
+            raise ValueError("method must be GET or POST")
+        self.url = url
+        self.method = method
+
+    def mapLogRecord(self, record):
+        """
+        Default implementation of mapping the log record into a dict
+        that is sent as the CGI data. Overwrite in your class.
+        Contributed by Franz Glasner.
+        """
+        return record.__dict__
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Send the record to the Web server as a percent-encoded dictionary
+        """
+        try:
+            req = ajax.open(self.method, self.url, async=False)
+            req.send(self.mapLogRecord(record))
+        except:
+            self.handleError(record)

--- a/www/src/Lib/logging/handlers.py
+++ b/www/src/Lib/logging/handlers.py
@@ -32,6 +32,8 @@ try:
 except ImportError: #pragma: no cover
     threading = None
 
+
+from brython_handlers import XMLHTTPHandler
 #
 # Some constants...
 #


### PR DESCRIPTION
Implement a `ConsoleHandler` (and `XMLHTTPHandler`, similar to the `HTTPHandler`) handler for the logging module which outputs the messages to the browser's debug console. Also, make `ConsoleHandler` the default `lastResort` handler.