### PR TITLE
make math module more python3.5 compliant

### DIFF
--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -317,7 +317,7 @@ var _mod = {
        var x1=float_check(x);
        var y1=float_check(y);
        return float(Math.sqrt(x1*x1 + y1*y1))},
-    inf: float(Infinity),
+    inf: float('inf'),
     isfinite:function(x) {return isFinite(float_check(x))},
     isinf:function(x) {return _b_.$isinf(float_check(x))},
     isnan:function(x) {return isNaN(float_check(x))},
@@ -368,7 +368,7 @@ var _mod = {
        var i=float(x1-x2)
        return _b_.tuple([i, float(x2)])
     },
-    nan: float(Number.NaN),
+    nan: float('nan'),
 	pi : float(Math.PI),
     pow: function(x,y) {
         var x1=float_check(x)

--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -331,9 +331,9 @@ var _mod = {
         var b = $ns['b'];
         var rel_tol = $ns['rel_tol'];
         var abs_tol = $ns['abs_tol'];
-        if (_b_.$isinf(a) || _b_.$isinf(b)){return false}
         if (rel_tol < 0.0 || abs_tol < 0.0) throw ValueError('tolerances must be non-negative')
         if (a == b){return True}
+        if (_b_.$isinf(a) || _b_.$isinf(b)){return false}
         var diff = _b_.$fabs(b - a);
         var result = ((diff <= _b_.$fabs(rel_tol * b)) || (diff <= _b_.$fabs(rel_tol * a))) || (diff <= _b_.$fabs(abs_tol));
         return result},

--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -318,6 +318,25 @@ var _mod = {
        var y1=float_check(y);
        return float(Math.sqrt(x1*x1 + y1*y1))},
     inf: float('inf'),
+    isclose:function(){
+        var $ns = $B.args("isclose",
+                          4,
+                          {a:null,b:null,rel_tol:null,abs_tol:null},
+                          ['a', 'b', 'rel_tol', 'abs_tol'],
+                          arguments,
+                          {rel_tol:1e-09, abs_tol:0.0}, 
+                          null, 
+                          null)
+        var a = $ns['a'];
+        var b = $ns['b'];
+        var rel_tol = $ns['rel_tol'];
+        var abs_tol = $ns['abs_tol'];
+        if (_b_.$isinf(a) || _b_.$isinf(b)){return false}
+        if (rel_tol < 0.0 || abs_tol < 0.0) throw ValueError('tolerances must be non-negative')
+        if (a == b){return True}
+        var diff = _b_.$fabs(b - a);
+        var result = ((diff <= _b_.$fabs(rel_tol * b)) || (diff <= _b_.$fabs(rel_tol * a))) || (diff <= _b_.$fabs(abs_tol));
+        return result},
     isfinite:function(x) {return isFinite(float_check(x))},
     isinf:function(x) {return _b_.$isinf(float_check(x))},
     isnan:function(x) {return isNaN(float_check(x))},

--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -317,6 +317,7 @@ var _mod = {
        var x1=float_check(x);
        var y1=float_check(y);
        return float(Math.sqrt(x1*x1 + y1*y1))},
+    inf: float(Infinity),
     isfinite:function(x) {return isFinite(float_check(x))},
     isinf:function(x) {return _b_.$isinf(float_check(x))},
     isnan:function(x) {return isNaN(float_check(x))},
@@ -367,7 +368,8 @@ var _mod = {
        var i=float(x1-x2)
        return _b_.tuple([i, float(x2)])
     },
-    pi : float(Math.PI),
+    nan: float(Number.NaN),
+	pi : float(Math.PI),
     pow: function(x,y) {
         var x1=float_check(x)
         var y1=float_check(y)

--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -57,7 +57,7 @@ $FloatDict.__bool__ = function(self){return _b_.bool(self.valueOf())}
 $FloatDict.__class__ = $B.$type
 
 $FloatDict.__eq__ = function(self,other){
-    if(isNaN(self) && isNaN(other)){return true}
+    if(isNaN(self) && isNaN(other)){return false}
     if(isinstance(other,_b_.int)) return self==other
     if(isinstance(other,float)) {
       // new Number(1.2)==new Number(1.2) returns false !!!

--- a/www/tests/test_math.py
+++ b/www/tests/test_math.py
@@ -103,10 +103,27 @@ class StrangeCeil:
 
 assert math.ceil(StrangeCeil()) == "this is a string"
 
+# tests for math.nan and math.inf (some tests could be shared with py_float.js)
 assert math.nan != math.nan
 assert math.inf > 10
 assert math.inf > -10
 assert -math.inf < 10
 assert -math.inf < -10
+
+# tests for math.isclose
+cases = [
+    {'a': 1e10, 'b': 1.00001e10, 'rel_tol': 1e-09, 'abs_tol': 0.0},
+    {'a': 1e-7, 'b': 1e-8, 'rel_tol': 1e-09, 'abs_tol': 0.0},
+    {'a': 1e-8, 'b': 1e-9, 'rel_tol': 1e-09, 'abs_tol': 0.0},
+    {'a': 1e10, 'b': 1.0001e10, 'rel_tol': 1e-09, 'abs_tol': 0.0},
+    {'a': 1.0, 'b': 1.0, 'rel_tol': 1e-09, 'abs_tol': 0.0},
+    {'a': 1.0, 'b': 1.01, 'rel_tol': 1, 'abs_tol': 0.0},
+    {'a': 1.0, 'b': 1.01, 'rel_tol': 0.001, 'abs_tol': 0.0},
+    {'a': math.nan, 'b': math.nan, 'rel_tol': 1e-09, 'abs_tol': 0.0},
+    {'a': math.inf, 'b': 10, 'rel_tol': 1e-09, 'abs_tol': 0.0}
+]
+expected = [False, False, False, False, True, True, False, False, False]
+for case, result in zip(cases, expected):
+    assert math.isclose(**case) == result
 
 print("passed all tests..")

--- a/www/tests/test_math.py
+++ b/www/tests/test_math.py
@@ -103,4 +103,10 @@ class StrangeCeil:
 
 assert math.ceil(StrangeCeil()) == "this is a string"
 
+assert math.nan != math.nan
+assert math.inf > 10
+assert math.inf > -10
+assert -math.inf < 10
+assert -math.inf < -10
+
 print("passed all tests..")


### PR DESCRIPTION
Implementation of `math.inf` and `math.nan`

Implementation of [`math.isclose`](https://docs.python.org/3.5/library/math.html#math.isclose) following [CPython implementation](https://github.com/python/cpython/blob/3.5/Modules/mathmodule.c#L1993) ([,pep485](https://www.python.org/dev/peps/pep-0485), except for complex numbers);

[1]