### PR TITLE
BUGFIX: StopIteration exception should have a value attribute (Fixes #502).

### DIFF
--- a/www/src/py_exceptions.js
+++ b/www/src/py_exceptions.js
@@ -252,7 +252,7 @@ var BaseException = function (){
     err.$py_error = true
     err.$stack = $B.frames_stack.slice()
     $B.current_exception = err
-    //placeholder//
+    eval('//placeholder//');
     return err
 }
 

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -999,6 +999,22 @@ b = [3, 4]
 odd = [x for x in a+b if x%2]
 assert odd == [1, 3]
 
+# Bug in generators
+
+def test_gen():
+    for i in range(1):
+        yield i
+    return 20
+
+g = test_gen()
+next(g)
+try:
+    next(g)
+except StopIteration as exc:
+    assert exc.value == 20
+
+
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -999,7 +999,7 @@ b = [3, 4]
 odd = [x for x in a+b if x%2]
 assert odd == [1, 3]
 
-# Bug in generators
+# Bug in generators (GitHub Issue #502)
 
 def test_gen():
     for i in range(1):


### PR DESCRIPTION
The `StopIteration` exception should have a `value` attribute. This was the intention in `py_exceptions.js` on line 364-5:

```javascript
var $exc = (BaseException+'').replace(/BaseException/g,name)
$exc = $exc.replace('//placeholder//', code)
```

Unfortunately, at least in Chromium, when converting `BaseException` to string, all comments
are discarded. The easiest fix I could think of, which is the content of this patch, is to replace
the comment with

```javascript
eval('//placeholder//');
```

which is not discarded and leads to the same result.