### PR TITLE
Fix the round method (Fixes Issue #506)

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1192,7 +1192,10 @@ $ReversedDict.$factory = reversed
 
 function round(arg,n){
     if(!isinstance(arg,[_b_.int,_b_.float])){
-        throw _b_.TypeError("type "+arg.__class__+" doesn't define __round__ method")
+        if (! hasattr(arg,'__round__'))
+            throw _b_.TypeError("type "+arg.__class__+" doesn't define __round__ method")
+        if(n===undefined) return getattr(arg,'__round__')()
+        else return getattr(arg,'__round__')(n)
     }
     
     if(isinstance(arg, _b_.float) && (arg.value === Infinity || arg.value === -Infinity)) {
@@ -1204,7 +1207,11 @@ function round(arg,n){
     if(!isinstance(n,_b_.int)){throw _b_.TypeError(
         "'"+n.__class__+"' object cannot be interpreted as an integer")}
     var mult = Math.pow(10,n)
-    return _b_.int.$dict.__truediv__(Number(Math.round(arg.valueOf()*mult)),mult)
+    if(isinstance(arg, _b_.float)) {
+        return _b_.float(_b_.int.$dict.__truediv__(Number(Math.round(arg.valueOf()*mult)),mult))
+    } else {
+        return _b_.int(_b_.int.$dict.__truediv__(Number(Math.round(arg.valueOf()*mult)),mult))
+    }
 }
 
 function setattr(obj,attr,value){

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1024,6 +1024,27 @@ except StopIteration as exc:
     assert exc.value == 20
 
 
+# Bug in round (GitHub Issue #506)
+
+class TestRound:
+    def __round__(self, n=None):
+        if n is None:
+            return 10
+        else:
+            return n
+tr = TestRound()
+
+
+assert type(round(3.0)) == int, "Round called without second argument should return int"
+assert type(round(3.1111, 3)) == float, "Round called without second argument should return same type as first arg"
+assert type(round(3.0, 0)) == float, "Round called without second argument should return same type as first arg"
+assert round(3.1111, 3) == 3.111
+assert type(round(0, 3)) == int, "Round called without second argument should return same type as first arg"
+assert round(tr, 3) == 3, "Round called on obj with __round__ method should use it"
+assert round(tr) == 10, "Round called on obj with __round__ method should use it"
+
+
+
 
 # ==========================================
 # Finally, report that all tests have passed


### PR DESCRIPTION
Fix Issue #506:
-- the result of the round method, if provided a second argument,
     should be the same type as the first argument

Additionaly the round method should use the `__round__` method
of the object if available (the previous implementation just threw
an error).