### PR TITLE
BUGFIX: Make CI tests pass again.

### DIFF
--- a/www/tests/brython_test_utils/unittest.py
+++ b/www/tests/brython_test_utils/unittest.py
@@ -78,12 +78,11 @@ class OneTimeTestResult(unittest.TestResult):
 
 
 def load_brython_test_cases(base_path=''):
-    return unittest.TestSuite(
-                NamedTestSuite('Brython : ' + label,
-                               (BrythonModuleTestCase(filenm, caption, base_path)
-                                        for filenm, caption in options)
-                               )
-                for label, options in utils.discover_brython_test_modules()
-            )
-
+    ret = []
+    for label, options in utils.discover_brython_test_modules():
+        tcs = []
+        for filenm, caption in options:
+            tcs.append(BrythonModuleTestCase(filenm, caption, base_path))
+        ret.append(NamedTestSuite('Brython :' + label, tcs))
+    return unittest.TestSuite(ret)
 


### PR DESCRIPTION
With the recent generators rewrite, CI started failing. This patch fixes the offending method. However, it is not clear to me, whether the problem is with the method or with the new implementation of generators.
