### PR TITLE
ReferenceError: _b_ is not defined

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -7571,7 +7571,7 @@ function run_script(script){
 
         // Print the error traceback on the standard error stream
         var name = $err.__name__
-        var $trace = _b_.getattr($err,'info')+'\n'+name+': '
+        var $trace = $B.builtins.getattr($err,'info')+'\n'+name+': '
         if(name=='SyntaxError' || name=='IndentationError'){
             $trace += $err.args[0]
         }else{$trace += $err.args}


### PR DESCRIPTION
Fix for javascript error "ReferenceError: _b_ is not defined" on syntax error in python code.

This problem prevented other more useful error messages from appearing, like the cause of the syntax error.