### PR TITLE
Remove some unnecesary imports

### DIFF
--- a/www/src/Lib/_abcoll.py
+++ b/www/src/Lib/_abcoll.py
@@ -8,7 +8,7 @@ via collections; they are defined here only to alleviate certain
 bootstrapping issues.  Unit tests are in test_collections.
 """
 
-from abc import ABCMeta, abstractmethod
+#from abc import ABCMeta, abstractmethod
 import sys
 
 __all__ = ["Hashable", "Iterable", "Iterator",

--- a/www/src/Lib/_abcoll.py
+++ b/www/src/Lib/_abcoll.py
@@ -8,6 +8,8 @@ via collections; they are defined here only to alleviate certain
 bootstrapping issues.  Unit tests are in test_collections.
 """
 
+# Brython fix me
+# ABCMeta is not used and abstractmethod is hardcoded in the module
 #from abc import ABCMeta, abstractmethod
 import sys
 

--- a/www/src/Lib/decimal.py
+++ b/www/src/Lib/decimal.py
@@ -141,7 +141,7 @@ __all__ = [
 __version__ = '1.70'    # Highest version of the spec this complies with
                         # See http://speleotrove.com/decimal/
 
-import copy as _copy
+#import copy as _copy
 import math as _math
 import numbers as _numbers
 import sys
@@ -151,6 +151,8 @@ try:
     DecimalTuple = _namedtuple('DecimalTuple', 'sign digits exponent')
 except ImportError:
     DecimalTuple = lambda *args: args
+    
+import _jsre as re
 
 # Rounding
 ROUND_DOWN = 'ROUND_DOWN'
@@ -619,7 +621,7 @@ class Decimal(object):
                self._is_special = True
                return self
 
-            import _jsre as re
+            #import _jsre as re
             _m=re.match("^\d*\.?\d*(e\+?\d*)?$", value)
             if not _m:
                self._is_special = True
@@ -6187,7 +6189,7 @@ ExtendedContext = Context(
 #    \Z
 #""", re.VERBOSE | re.IGNORECASE).match
 
-import _jsre as re
+#import _jsre as re
 _all_zeros = re.compile('0*$').match
 _exact_half = re.compile('50*$').match
 
@@ -6476,6 +6478,6 @@ else:
     del s1, s2, name
     from _decimal import *
 
-if __name__ == '__main__':
-    import doctest, decimal
-    doctest.testmod(decimal)
+#if __name__ == '__main__':
+    #import doctest, decimal
+    #doctest.testmod(decimal)

--- a/www/src/Lib/decimal.py
+++ b/www/src/Lib/decimal.py
@@ -141,6 +141,7 @@ __all__ = [
 __version__ = '1.70'    # Highest version of the spec this complies with
                         # See http://speleotrove.com/decimal/
 
+# Copy is not used at this moment in the module
 #import copy as _copy
 import math as _math
 import numbers as _numbers
@@ -151,7 +152,8 @@ try:
     DecimalTuple = _namedtuple('DecimalTuple', 'sign digits exponent')
 except ImportError:
     DecimalTuple = lambda *args: args
-    
+
+# Moved from below as it is used globally    
 import _jsre as re
 
 # Rounding
@@ -6478,6 +6480,8 @@ else:
     del s1, s2, name
     from _decimal import *
 
+# Brython fix me
+# This is not used at this moment
 #if __name__ == '__main__':
     #import doctest, decimal
     #doctest.testmod(decimal)


### PR DESCRIPTION
In this commit I would like to start a work to check if there are unused imports (e.g., [here](https://github.com/brython-dev/brython/pull/527/commits/bc194cf14325772095c2b55fb295b51070918440#diff-ea4cba5d25a8cf9530ecbfa3b1b89bb9R11)) or if there is code that is unnecessary on production on a client side (e.g., [here](https://github.com/brython-dev/brython/pull/527/commits/bcf6cd35fad8910760371346b5cb4fed1ddfaa2c#diff-977f5e6deb9b6110547b2675d7c7b1feR6481)).

## Pros:

If some stuff is removed it will impact positively in the performance of the import machinery and it would make some modules/packages less dependent so a production bundle can be lighter.

## Cons:
We should be checking CPython changes for several modules on each CPython release to check if some of our changes should be updated because there is new funcionality incompatible with our changes.

@PierreQuentel Do you think it is worth the effort? I think this is something we should start analysing as people is claiming improvements in the performance and in the size of a potential production bundle of code.

Other ideas: 

* change `re` with `_jsre` when possible.
* reimplement some python widely used stuff in js.
* Remove all the `if __name__ == '__main__'` from the modules (as it has no sense to me on a client side environment).
* Mock some functionality as `argparse` (as it has no sense to me on a client side environment).
* other ideas...?

If do you think it is not a good idea just reject the PR.