### PR TITLE
Fix for javascript error "TypeError: $.get_class is not a function" o…

### DIFF
--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -6,7 +6,7 @@ var $ObjectDict = _b_.object.$dict
 
 function $err(op,other){
     var msg = "unsupported operand type(s) for "+op
-    msg += ": 'float' and '"+$.get_class(other).__name__+"'"
+    msg += ": 'float' and '"+$B.get_class(other).__name__+"'"
     throw _b_.TypeError(msg)
 }
 


### PR DESCRIPTION
…n python error for treating a number like a string (concatenation)

With python code:
resultString = myNumber + "someString"

when it should be:
resultString = str(myNumber) + "someString"

resulted in javascript error:
"TypeError: $.get_class is not a function"

instead of a more useful exception to show where in the python code the
problem originates from.