### PR TITLE
BUGFIX: Don't assume exceptions have arguments (see Issue #539)

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -149,7 +149,7 @@ var pyobj2jsobj=$B.pyobj2jsobj=function(pyobj){
             }catch(err){
                 console.log(err)
                 console.log(_b_.getattr(err,'info'))
-                console.log(err.__name__+':', err.args[0])
+                console.log(err.__name__+':', err.args.length > 0 ? err.args[0] : '' )
                 throw err
             }
         }
@@ -386,9 +386,15 @@ $JSObjectDict.__setattr__ = function(self,attr,value){
                 catch(err){
                     err = $B.exception(err)
                     var info = _b_.getattr(err,'info')
-                    err.toString = function(){
-                        return info+'\n'+err.__class__.__name__+
-                        ': '+_b_.repr(err.args[0])
+                    if (err.args.length > 0) {
+                        err.toString = function(){
+                            return info+'\n'+err.__class__.__name__+
+                            ': '+_b_.repr(err.args[0])
+                        }
+                    } else {
+                        err.toString = function(){
+                            return info+'\n'+err.__class__.__name__
+                        }
                     }
                     console.log(err+'')
                     throw err


### PR DESCRIPTION
The issue doesn't have an example allowing me to reproduce the error, so
I can't say for sure that the error is fixed.

Also, I am not sure, whether the error is not in some other place:
perhaps exceptions should always have at least one argument (the
message)... So please feel free to discard the pull request if it fixes just the symptoms
and not the cause.