### PR TITLE
Fix --modules option of brython.py

### DIFF
--- a/setup/brython.py
+++ b/setup/brython.py
@@ -75,7 +75,8 @@ if args.modules:
     if os.path.exists(include_path):
         with open(include_path, encoding="utf-8") as fobj:
             bundle_list = [m.strip() for m in fobj if m.strip()]
-        mods = {k:v for (k, v) in mods.items() if k in bundle_list}
+            print('bundled modules', bundle_list)
+            mods = {k:v for (k, v) in mods.items() if k in bundle_list}
     
     # save new version of brython_modules
     with open("brython_modules.js", "w", encoding="utf-8") as out:


### PR DESCRIPTION
`python -m brython --modules` didn't produce any changes in `brython_modules.js`. It was an indentation issue. I also added a print for information about the modules to be bundled.