### PR TITLE
Fix Isseu 560: Derived classmethods passed wrong parameters.

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -168,9 +168,14 @@ $B.make_method = function(attr, klass, func){
         return func
       case 'classmethod':
         // class method : called with the class as first argument
-        method = function(){
-            var class_method = function(){                
-                var local_args = [klass.$factory]
+        method = function(obj){
+            var class_method = function(){
+                var local_args=0;
+                if (obj !== undefined) {
+                    local_args = [obj.__class__.$factory]
+                } else {
+                    local_args = [klass.$factory]
+                }
                 var pos=local_args.length
                 for(var i=0, _len_i = arguments.length; i < _len_i;i++){
                     local_args[pos++]=arguments[i]

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1170,6 +1170,20 @@ a.difference_update([5])
 assert a == {10}
 assert b == {5, 10}
 
+# issue 560
+class Base:
+    @classmethod
+    def test(cls):
+        return cls
+
+class Derived(Base):
+    def __init__(self):
+        pass
+
+assert Derived.test() == Derived
+d = Derived()
+assert d.test() == Derived
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
The following code fails the second assert in Brython (but passes in
CPython).

```python
class Base:
    @classmethod
    def test(cls):
        return cls

class Derived(Base):
    def __init__(self):
        pass

assert Derived.test() == Derived
d = Derived()
assert d.test() == Derived
```

The reason is that d.test() calls Base.test with the class Base as first
parameter instead of the correct Derived class.