### PR TITLE
Exclude from git files created in npm and setup/data after make_dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@
 *.rar
 *.tar
 *.zip
-
+*.tar.bz2
 
 # Logs and databases
 *.log
@@ -78,3 +78,6 @@ nosetests.xml
 # Temporary QUnit folder
 #qunit/
 
+# Files created by make_dist
+npm/*.js
+setup/data/*.js


### PR DESCRIPTION
After make_dist, brython.js and brython_stdlib.js are copied to the directories npm and setup/data and some git tools believe they should be added. The update to .gitignore ignores the files even if present