### PR TITLE
tag creation (revamped) - maketag

### DIFF
--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -227,7 +227,7 @@
                     'PROGRESS','RB','RP','RT','RTC','RUBY','SECTION','SOURCE',
                     'TEMPLATE','TIME','TRACK','VIDEO','WBR',
                      // HTML5.1 tags
-                    'DETAILS','DIALOG','MENUITEM','PICTURE','SUMMARY',]
+                    'DETAILS','DIALOG','MENUITEM','PICTURE','SUMMARY']
 
         for(var i=0, len = $tags.length; i < len; i++) {
             _maketag($tags[i])

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -179,7 +179,7 @@
         // are defined in py_dom.js
 
         function makeFactory(tagName){
-            var factory = function(textval=""){
+            var factory = function(){
                 if(tagName=='SVG'){
                     var res = $B.DOMNode(document.createElementNS("http://www.w3.org/2000/svg", "svg"))
                 }else{

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -91,7 +91,6 @@
 
     function _maketag(tname) {
 
-        var $B = __BRYTHON__
         var _b_ = $B.builtins
         var $TagSumDict = $B.$TagSum.$dict
 

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -87,7 +87,6 @@
 
     // creation of an HTML element
     modules['browser.html'] = {}
-    $B.tag_classes = {}  // init here before 1st call to maketag
 
     function _maketag(tname) {
 
@@ -228,6 +227,7 @@
                      // HTML5.1 tags
                     'DETAILS','DIALOG','MENUITEM','PICTURE','SUMMARY']
 
+        $B.tag_classes = {}  // init here before 1st call to maketag
         for(var i=0, len = $tags.length; i < len; i++) {
             _maketag($tags[i])
         }

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -233,7 +233,7 @@
         }
     })(__BRYTHON__)
 
-    modules['browser.html']['_maketag'] = _maketag  // add maketag in mod
+    modules['browser']['maketag'] = _maketag  // add maketag in mod
 
     modules['javascript'] = {
         __file__:$B.brython_path+'/libs/javascript.js',

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -88,7 +88,7 @@
     // creation of an HTML element
     modules['browser.html'] = {}
 
-    function _maketag(tname) {
+    function _maketag(tname, add2mod=false) {
 
         var _b_ = $B.builtins
         var $TagSumDict = $B.$TagSum.$dict
@@ -194,12 +194,14 @@
             return factory
         }
 
-        var obj = modules['browser.html']
         var dicts = $B.tag_classes
         dicts[tname] = makeTagDict(tname)
-        obj[tname] = makeFactory(tname)
-        dicts[tname].$factory = obj[tname]
-        return obj[tname]
+        var newtag = makeFactory(tname)
+        dicts[tname].$factory = newtag
+        if(add2mod) {
+            modules['browser.html'][tname] = newtag
+        }
+        return newtag
     }
 
     (function($B) {
@@ -229,7 +231,7 @@
 
         $B.tag_classes = {}  // init here before 1st call to maketag
         for(var i=0, len = $tags.length; i < len; i++) {
-            _maketag($tags[i])
+            _maketag($tags[i], true)
         }
     })(__BRYTHON__)
 


### PR DESCRIPTION
Allow custom tag creation using the same internal code which is used to create the standard HTML tags, by exposing a function `maketag`

Compared with the previous version:

  - `maketag` instead of `_maketag`
  - `maketag` is exposed under the module `browser` instead of `browser.html` to avoid pollution of the latter (whose attributes not starting with `__` are all HTML tags)
  - `maketag` supports a 2nd parameter `add2mod` (default: `False`) which decides if the created tag is added to `browser.html` (standard tags are of course added)
  - Removal of the previous `createTextNode` and associated `_TEXT` tag

There should be no expected side effect, because the code is being *exposed* rather than changed via `maketag`