### PR TITLE
Asyncio fs: Implements an async open method to access local/remote files.

### DIFF
--- a/www/doc/en/asyncfs.md
+++ b/www/doc/en/asyncfs.md
@@ -1,0 +1,93 @@
+module **asyncio.fs**
+-----------------------
+The module provides asynchronous access to local / remote files.
+
+
+Below is a commented example which can be run from the repl.
+
+```python
+from browser import document as doc, html
+import asyncio.fs as afs
+
+# Create an input element & append it to the page
+i = html.INPUT(type='file')
+doc <= i
+
+# Wait for the user to select a file ...
+
+# Once the user has selected the file
+# we can open it using the `open` method
+ff = afs.open(i.files[0])
+
+# The method is a coroutine, so it returns a `asyncio.Future`
+# Once the file is read, we can retrieve the result with
+f = ff.result()
+
+# The result is an instance of `asyncio.fs.BrowserFile`
+# which inherits from `io.StringIO`
+# so you can access it with `read`, `readlines`,
+# and all the other methods of `io.StringIO`
+print(f.read())
+
+# It also has an additional method `save`
+# which downloads the file into the Downloads
+# directory or, depending on user settings,
+# opens a file dialog allowing him to choose where
+# to save the file
+f.save()
+```
+
+It should be noted that the `asyncio.fs.BrowserFile` object keeps the file contents in memory,
+so one should be careful with large files. The `open` method takes an optional argument
+`max_size` which specifies the maximum size (in bytes) of the file it is willing to load.
+If the parameter is provided and the size of the file is bigger than this, it will raise
+an `IOError` exception.
+
+The `asyncio.fs.BrowserFile` object supports the `write` method. If you
+modify the file using this method, the `save` method will save the modified contents.
+
+The `asyncio.fs.open` method accepts either a [File](https://developer.mozilla.org/cs/docs/Web/API/File)
+object or an url. In the latter case it will download the url and return the contents as
+an `asyncio.fs.BrowserFile` object. However, the `save` method will still save the file locally, **not**
+remotely.
+
+**Note that remote reading is not fully tested yet.**
+
+
+The module also contains a convenience method
+
+```
+    asyncio.fs.open_local
+```
+
+Which opens a file dialog which the user can use to pick a file. The method
+returns a `asyncio.Future` which resolves into an `asyncio.fs.BrowserFile`
+with the file contents when the file is read. The method works by
+appending an input to the document body, registering a change handler for it,
+programmatically clicking it, and then immediately deleting it from the document.
+
+The above example code is meant to be run in the repl. Due to the asynchronous nature
+of the methods, when run from a script, it should be wrapped in a coroutine, e.g. as follows:
+
+
+```python
+import asyncio
+import asyncio.fs as afs
+
+@asyncio.coroutine
+def process_file(file_object = None):
+
+    if file_object is None:
+        input = yield afs.open_local()
+    else:
+        input = yield afs.open(file_object)
+
+    output = yield afs.open('processed.txt','w')
+
+    for ln in input.readlines():
+        output.write(ln.replace('\n','\r\n'))
+
+    output.save()
+
+asyncio.ensure_future(process_file())
+```

--- a/www/doc/en/asyncio.md
+++ b/www/doc/en/asyncio.md
@@ -14,7 +14,7 @@ import asyncio
 def test_wget(urls):
     results = []
     for u in urls:
-        req = yield from asyncio.HTTPRequest(u)
+        req = yield asyncio.HTTPRequest(u)
         results.append(req.response)
     return results
 

--- a/www/doc/en/index.html
+++ b/www/doc/en/index.html
@@ -75,6 +75,7 @@ window.load = docs.load
 <br>
 <br><a class="navig" href="#" onClick="load('javascript.md','content')">javascript</a>
 <br><a class="navig" href="#" onClick="load('asyncio.md','content')">asyncio</a>
+<br><a class="navig" href="#" onClick="load('asyncfs.md','content')">asyncio.fs</a>
 
 </div>
 

--- a/www/doc/en/index_static.html
+++ b/www/doc/en/index_static.html
@@ -115,6 +115,7 @@ for elt in document[target].get(selector='.python'):
 <br>
 <br><a class="navig" href="javascript.html">javascript</a>
 <br><a class="navig" href="asyncio.html">asyncio</a>
+<br><a class="navig" href="asyncfs.html">asyncio.fs</a>
 </div>
 
 <h4>Working with Brython</h4>

--- a/www/doc/en/static_index.html
+++ b/www/doc/en/static_index.html
@@ -87,6 +87,7 @@ load()
 <br>
 <br><a class="navig" href="?page=javascript">javascript</a>
 <br><a class="navig" href="?page=asyncio">asyncio</a>
+<br><a class="navig" href="?page=asyncfs">asyncio.fs</a>
 </div>
 
 <h4>Working with Brython</h4>

--- a/www/src/Lib/asyncio/coroutines.py
+++ b/www/src/Lib/asyncio/coroutines.py
@@ -16,13 +16,14 @@ def get_continuation(generator, final_result):
             cb = get_continuation(generator, final_result)
             next_result.add_done_callback(cb)
         except StopIteration as ex:
-            if hasattr(ex,'value'):
+            if hasattr(ex, 'value'):
                 final_result.set_result(ex.value)
             else:
                 final_result.set_result(None)
         except Exception as ex:
             final_result.set_exception(ex)
     return _cb
+
 
 @decorator
 def coroutine(func):
@@ -60,6 +61,7 @@ def coroutine(func):
     run.__coroutine = True
     run.__name__ = func.__name__
     return run
+
 
 def iscoroutine(obj):
     return hasattr(obj, '__coroutine')

--- a/www/src/Lib/asyncio/coroutines.py
+++ b/www/src/Lib/asyncio/coroutines.py
@@ -49,12 +49,16 @@ def coroutine(func):
             first_result = next(generator)
             _cb = get_continuation(generator, final_result)
             first_result.add_done_callback(_cb)
-        except StopIteration:
-            final_result.set_result(None)
+        except StopIteration as ex:
+            if hasattr(ex, 'value'):
+                final_result.set_result(ex.value)
+            else:
+                final_result.set_result(None)
         except Exception as ex:
             final_result.set_exception(ex)
         return final_result
     run.__coroutine = True
+    run.__name__ = func.__name__
     return run
 
 def iscoroutine(obj):

--- a/www/src/Lib/asyncio/fs.py
+++ b/www/src/Lib/asyncio/fs.py
@@ -1,0 +1,171 @@
+"""
+    Asynchronous access to local/remote files.
+
+    Usage:
+
+        from browser import document as doc, html
+        import asyncio.fs as afs
+
+        # Create an input element & append it to the page
+        i = html.INPUT(type='file')
+        doc <= i
+
+        # Wait for the user to select a file ...
+
+        # Once the user has selected the file
+        # we can open it using the `open` method
+        ff = afs.open(i.files[0])
+
+        # The method is a coroutine, so it returns a `asyncio.Future`
+        # Once the file is read, we can retrieve the result with
+        f = ff.result()
+
+        # The result is an instance of `asyncio.fs.BrowserFile`
+        # which inherits from `io.StringIO`
+        # so you can access it with `read`, `readlines`,
+        # and all the other methods of `io.StringIO`
+        print(f.read())
+
+        # It also has an additional method `save`
+        # which downloads the file into the Downloads
+        # directory or, depending on user settings,
+        # opens a file dialog allowing him to choose where
+        # to save the file
+        f.save()
+
+
+    Note: The `asyncio.fs.BrowserFile` object keeps the file contents in memory.
+
+    Note: The `asyncio.fs.BrowserFile` object supports the `write` method. If you
+    modify the file using this method, the `save` method will save
+    the modified contents.
+
+    Note: The `asyncio.fs.open` method also accepts urls. In that case it will
+    download the url and return the contents as an `asyncio.fs.BrowserFile` object.
+    However, the `save` method will still save the file locally, **not** remotely.
+
+
+    The module also contains a convenience method
+
+    `asyncio.fs.open_local`
+
+    Which opens a file dialog which the user can use to pick a file. The method
+    returns a `asyncio.Future` which resolves into an `asyncio.fs.BrowserFile`
+    with the file contents when the file is read. The method works by
+    appending an input to the document body, registering a change handler for it,
+    programmatically clicking it, and then immediately deleting it from the document.
+"""
+import io
+import base64
+
+from browser import window, document as doc, html
+
+from .futures import Future
+from .http import HTTPRequest
+from .coroutines import coroutine
+
+
+class BrowserFile(io.StringIO):
+    def __init__(self, name, content='', mime_type='text/plain;charset=utf-8'):
+        super().__init__(content)
+        self._mime_tp = mime_type
+        self._name = name
+
+    def as_data_url(self, mime_type=None):
+        """
+            Returns the file contents as a data-uri (suitable to assign to
+            a src attribute of images, href attribute of links, etc.)
+        """
+        if mime_type is None:
+            mime_type = self._mime_tp
+        return 'data:'+self._mime_tp+';base64,'+base64.b64encode(self.getvalue().encode('utf-8')).decode('ascii')
+
+    def save(self):
+        """
+            Saves the file locally.
+
+            It works by silently appending a link element to the body. The link element has an
+            appropriate download attribute (the name of the file) and href attribute
+            (the data-uri with the contents of the file). This element is then programmatically
+            clicked and removed from the body.
+        """
+        link = html.A(href=self.as_data_url(), download=self._name)
+        doc <= link
+        link.click()
+        doc.body.removeChild(link)
+
+
+class FutureLocalFile(Future):
+    def __init__(self, file):
+        super().__init__()
+        self._reader = window.FileReader.new()
+        self._reader.bind('load', self._load_handler)
+        self._reader.bind('error', self._error_handler)
+        self._reader.readAsText(file)
+        self._name = file.name
+        self._mime = file.type
+
+    def cancel(self):
+        self._reader.abort()
+
+    def _load_handler(self, evt):
+        self.set_result(BrowserFile(self._name, evt.target.result, mime_type=self._mime))
+
+    def _error_handler(self, evt):
+        self.set_exception(IOError(str(self._reader.error)))
+
+
+def open_local():
+    """
+    Opens a file dialog which the user can use to pick a file.
+
+    Returns:
+        asyncio.Future: Returns a future which, upon reading the file,
+                        resolves to an `asyncio.fs.BrowserFile` object with
+                        the file contents.
+
+    The method works by appending an input element to the document body, registering a change
+    handler for it, programmatically clicking it, and then immediately
+    deleting it from the document.
+    """
+
+    i = html.INPUT(type='file')
+    result = Future()
+
+    @coroutine
+    def change_handler(evt):
+        ret = yield open(i.files[0])
+        result.set_result(ret)
+
+    i.bind('change', change_handler)
+    doc <= i
+    i.click()
+    doc.body.removeChild(i)
+    return result
+
+
+@coroutine
+def open(file, mode='r', size_limit=None):
+    """
+        Opens a local or remote file and returns a Future, which, upon completion,
+        will resolve to an `asyncio.fs.BrowserFile` object with the file contents.
+
+        Args:
+          file(instance of the javascript File object/str):
+                if opening a local file, the parameter must be an instance of the javascript File object
+                if opening a remote file, the parameter should be the url of the file
+          mode(str): unused, present for compatibility with the builtin open method
+    """
+    if 'r' in mode:
+        if type(file) == str:
+            req = yield HTTPRequest(file)
+            if size_limit is not None and req.response.length > size_limit:
+                raise IOError("Maximum file size exceeded:"+str(req.response.length)+"(max allowed:"+str(size_limit)+")")
+            ret = BrowserFile(file, req.response)
+        else:
+            if size_limit is not None and file.size > size_limit:
+                raise IOError("Maximum file size exceeded:"+str(file.size)+"(max allowed:"+str(size_limit)+")")
+            ret = yield FutureLocalFile(file)
+    else:
+        ret = BrowserFile(file, '')
+    return ret

--- a/www/src/Lib/asyncio/futures.py
+++ b/www/src/Lib/asyncio/futures.py
@@ -1,14 +1,18 @@
 
 from .events import get_event_loop
 
+
 class InvalidStateError(Exception):
     pass
+
 
 class CancelledError(Exception):
     pass
 
+
 class TimeoutError(Exception):
     pass
+
 
 class Future:
     """
@@ -49,7 +53,6 @@ class Future:
         self._schedule_callbacks()
         return True
 
-
     def cancelled(self):
         """Return True if the future was cancelled."""
         return self._status == Future.STATUS_CANCELED
@@ -75,7 +78,6 @@ class Future:
         if self._status == Future.STATUS_ERROR:
             raise self._exception
         return self._result
-
 
     def exception(self):
         """
@@ -186,6 +188,7 @@ class GatheredFuture(Future):
             else:
                 results.append(fut.result())
         self.set_result(results)
+
 
 class SleepFuture(Future):
     def __init__(self, seconds, result=None):


### PR DESCRIPTION
The discussion on Google Groups here https://groups.google.com/d/topic/brython/HJzUFpnXNik/discussion
led me to add a simple asyncio-based implementation to access local/remote files from the browser.

For example, a simple unix-to-dos line endings converter could be written using the new `asyncio.fs` module as follows:

```python
import asyncio
import asyncio.fs as afs

@asyncio.coroutine
def todos(file_object = None):

    if file_object is None:
        input = yield afs.open_local()
    else:
        input = yield afs.open(file_object)

    output = yield afs.open('processed.txt','w')

    for ln in input.readlines():
        output.write(ln.replace('\n','\r\n'))

    output.save()

asyncio.ensure_future(todos())
```