### PR TITLE
Fix behavior of select_one ... return None on no results found

### DIFF
--- a/www/src/py_dom.js
+++ b/www/src/py_dom.js
@@ -1182,7 +1182,7 @@ DOMNodeDict.select_one = function(self, selector){
         throw _b_.TypeError("DOMNode object doesn't support selection by selector")
     }
     var res = self.elt.querySelector(selector)
-    if(res !== null) {
+    if(res === null) {
         return None
     }
     return DOMNode(res)


### PR DESCRIPTION
Putting it in action has revealed that the comparison for returning the results was reversed