### PR TITLE
To follow the logic of how scripts are found in the html code

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -8082,7 +8082,7 @@ function _run_scripts(options) {
         for(var $i=0;$i<options.ipy_id.length;$i++){
             $elts.push(document.getElementById(options.ipy_id[$i]));
         }
-        }else{
+    }else{
         var scripts=document.getElementsByTagName('script'),$elts=[]
         // Freeze the list of scripts here ; other scripts can be inserted on
         // the fly by viruses


### PR DESCRIPTION
The `}else{` was indented to the next level, making it *really* difficult to follow the logic. Not a code breaking change.