### PR TITLE
Make bind convert the Event arg to a Python obj before calling handler

### DIFF
--- a/www/src/Lib/browser/websocket.py
+++ b/www/src/Lib/browser/websocket.py
@@ -5,5 +5,7 @@ if hasattr(window, 'WebSocket'):
     WebSocket = window.WebSocket.new
 else:
     supported = False
-    def WebSocket(*args,**kw):
-        raise NotImplementedError
+
+    class WebSocket:
+        def __init__(self, *args):
+            raise NotImplementedError

--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -423,7 +423,10 @@ $JSObjectDict.__str__ = $JSObjectDict.__repr__
 var no_dict = {'string':true,'function':true,'number':true,'boolean':true}
 
 $JSObjectDict.bind = function(self, evt, func){
-    self.js.addEventListener(evt, func)
+    var js_func = function(ev) {
+        return func(jsobj2pyobj(ev))
+    }
+    self.js.addEventListener(evt, js_func)
     return _b_.None
 }
 


### PR DESCRIPTION
- also, even if not implemented, WebSocket should not accept keyword
arguments and should be a class.