### PR TITLE
Check whether attr is a string in setattr on jsobjects (Fixes #744).

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -384,7 +384,7 @@ $JSObjectDict.__repr__ = function(self){
 }
 
 $JSObjectDict.__setattr__ = function(self,attr,value){
-    if(attr.substr(0,2)=='$$'){
+    if(attr.substr && attr.substr(0,2)=='$$'){
         // aliased attribute names, eg "message"
         attr = attr.substr(2)
     }

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1611,6 +1611,15 @@ def simple_coroutine():
 
 fut = simple_coroutine()
 assert fut.result() == 10
+
+# issue 744: Javascript objects should allow integer attribute names.
+from browser import window
+a = window.Uint8ClampedArray.new(10)
+
+for i in range(10):
+    a[i] = i
+    assert a[i] == i
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
Javascript objects (as opposed to Python objects) can have integer
attributes, so we should not assume that attr is a string.