### PR TITLE
Fix equality comparison for types (Fixes #749)

### DIFF
--- a/www/src/py_dict.js
+++ b/www/src/py_dict.js
@@ -110,7 +110,7 @@ var $iterator_wrapper = function(items,klass){
         __class__:klass,
         __eq__:function(other){
             // compare set of items to other
-            return getattr(toSet(items), "__eq__")(other)
+            return $B.rich_comp("__eq__", toSet(items), other)
         },
         __iter__:function(){items.iter.i=0; return res},
         __len__:function(){return items.length()},
@@ -151,9 +151,9 @@ $DictDict.__contains__ = function(){
 
     var _key=hash(item)
     if (self.$str_hash[_key]!==undefined &&
-        _b_.getattr(item,'__eq__')(self.$str_hash[_key])){return true}
+        $B.rich_comp("__eq__", item, self.$str_hash[_key])){return true}
     if (self.$numeric_dict[_key]!==undefined &&
-        _b_.getattr(item,'__eq__')(_key)){return true}
+        $B.rich_comp("__eq__", item, _key)){return true}
     if (self.$object_dict[_key] !== undefined) {
         // If the key is an object, its hash must be in the dict keys but the
         // key itself must compare equal to the key associated with the hash
@@ -165,9 +165,7 @@ $DictDict.__contains__ = function(){
         //     a = {'u': 'a', X(): 'b'}
         //     assert set(a.values())=={'a', 'b'}
         //     assert not X() in a
-
-       var _eq = getattr(item, '__eq__')
-       if(_eq(self.$object_dict[_key][0])){return true}
+       return $B.rich_comp("__eq__", item, self.$object_dict[_key][0])
     }
     return false
 }
@@ -224,17 +222,17 @@ $DictDict.__eq__ = function(){
             return false
     }
     for(var k in self.$numeric_dict){
-        if(!_b_.getattr(other.$numeric_dict[k],'__eq__')(self.$numeric_dict[k])){
+        if(!$B.rich_comp("__eq__", other.$numeric_dict[k], self.$numeric_dict[k])){
             return false
         }
     }
     for(var k in self.$string_dict){
-        if(!_b_.getattr(other.$string_dict[k],'__eq__')(self.$string_dict[k])){
+        if(!$B.rich_comp("__eq__", other.$string_dict[k], self.$string_dict[k])){
             return false
         }
     }
     for(var k in self.$object_dict){
-        if(!_b_.getattr(other.$object_dict[k][1],'__eq__')(self.$object_dict[k][1])){
+        if(!$B.rich_comp("__eq__", other.$object_dict[k][1], self.$object_dict[k][1])){
             return false
         }
     }
@@ -265,7 +263,7 @@ $DictDict.__getitem__ = function(){
     // since the key is more complex use 'default' method of getting item
 
     var _key = _b_.hash(arg),
-        _eq = _b_.getattr(arg, '__eq__')
+        _eq = function(other){return $B.rich_comp('__eq__', arg, other)}
 
     var sk = self.$str_hash[_key]
     if (sk!==undefined && _eq(sk)){
@@ -438,7 +436,7 @@ $DictDict.__setitem__ = function(self,key,value){
     // if we got here the key is more complex, use default method
 
     var _key=hash(key)
-    var _eq=getattr(key, '__eq__')
+    var _eq=function(other){return $B.rich_comp("__eq__", key, other)};
 
     if(self.$numeric_dict[_key]!==undefined && _eq(_key)){
         self.$numeric_dict[_key] = value

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -33,7 +33,7 @@ $ListDict.__contains__ = function(self,item){
         arguments,{},null,null),
         self=$.self,
         item=$.item
-    var _eq = getattr(item, '__eq__')
+    var _eq = function(other){return $B.rich_comp("__eq__", item, other)}
     var i=0
     while(i<self.length) {
         if(_eq(self[i])) return true
@@ -98,7 +98,7 @@ $ListDict.__eq__ = function(self,other){
        if(other.length==self.length){
             var i=self.length
             while(i--) {
-               if(!getattr(self[i],'__eq__')(other[i])) return false
+                if(!$B.rich_comp("__eq__", self[i], other[i])) return false
             }
             return true
        }
@@ -158,7 +158,7 @@ $ListDict.__ge__ = function(self,other){
     var i=0
     while(i<self.length){
         if(i>=other.length) return true
-        if(getattr(self[i],'__eq__')(other[i])){i++}
+        if($B.rich_comp("__eq__", self[i], other[i])){i++}
         else return(getattr(self[i],"__ge__")(other[i]))
     }
 
@@ -176,7 +176,7 @@ $ListDict.__gt__ = function(self,other){
     var i=0
     while(i<self.length){
         if(i>=other.length) return true
-        if(getattr(self[i],'__eq__')(other[i])){i++}
+        if($B.rich_comp("__eq__", self[i], other[i])){i++}
         else return(getattr(self[i],'__gt__')(other[i]))
     }
     // other starts like self, but is as long or longer
@@ -356,7 +356,7 @@ $ListDict.count = function(){
     var $=$B.args('count',2,{self:null,x:null},['self','x'],
         arguments,{},null,null)
     var res = 0
-    _eq=getattr($.x, '__eq__')
+    _eq=function(other){return $B.rich_comp("__eq__", $.x, other)}
     var i=$.self.length
     while (i--) if (_eq($.self[i])) res++
     return res
@@ -375,7 +375,7 @@ $ListDict.index = function(){
         ['self','x','start','stop'],arguments,
         {start:null,stop:null},null,null),
         self=$.self, start=$.start, stop=$.stop
-    var _eq = getattr($.x, '__eq__')
+    var _eq = function(other){return $B.rich_comp("__eq__", $.x, other)}
     if(start===null){start=0}
     else{
         if(start.__class__===$B.LongInt.$dict){
@@ -421,7 +421,7 @@ $ListDict.remove = function(){
     var $=$B.args('remove',2,{self:null,x:null},['self','x'],arguments,{},
         null,null)
     for(var i=0, _len_i = $.self.length; i < _len_i;i++){
-        if(getattr($.self[i],'__eq__')($.x)){
+        if($B.rich_comp("__eq__", $.self[i], $.x)){
             $.self.splice(i,1)
             return $N
         }

--- a/www/src/py_long_int.js
+++ b/www/src/py_long_int.js
@@ -434,8 +434,7 @@ $LongIntDict.__mul__ = function(self, other){
     switch(self){
         case Number.NEGATIVE_INFINITY:
         case Number.POSITIVE_INFINITY:
-            var eq = _b_.getattr(other, '__eq__')
-            if(eq(0)){return NaN} // infinity * 0 = NaN
+            if ($B.rich_comp("__eq__",other,0)){return NaN} // infinity * 0 = NaN
             else if(_b_.getattr(other, '__gt__')(0)){return self}
             else{return -self}
     }

--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -94,7 +94,7 @@ $ObjectDict.__eq__ = function(self,other){
     if (_class.$native || _class.__name__ == 'function') {
        var _class1=$B.get_class(other)
        if (!_class1.$native && _class1.__name__ != 'function') {
-          return _b_.getattr(other, '__eq__')(self)
+           return $B.rich_comp("__eq__", other, self)
        }
     }
     return self===other
@@ -316,8 +316,7 @@ $ObjectDict.__new__ = function(cls){
 }
 
 $ObjectDict.__ne__ = function(self,other){
-    var eq = _b_.getattr(self, "__eq__")
-    return !eq(other)
+    return !$B.rich_comp("__eq__", self, other)
 }
 
 $ObjectDict.__repr__ = function(self){

--- a/www/src/py_range_slice.js
+++ b/www/src/py_range_slice.js
@@ -185,7 +185,7 @@ $RangeDict.count = function(self, ob){
     if(_b_.isinstance(ob, [_b_.int, _b_.float, _b_.bool])){
         return _b_.int($RangeDict.__contains__(self, ob))
     }else{
-        var comp = _b_.getattr(ob, '__eq__'),
+        var comp = function(other){return $B.rich_comp("__eq__", ob, other)},
             it = $RangeDict.__iter__(self)
             _next = $RangeIterator.$dict.__next__,
             nb = 0,
@@ -211,7 +211,7 @@ $RangeDict.index = function(self, other){
     try{
         other = $B.int_or_bool(other)
     }catch(err){
-        var comp = _b_.getattr(other, '__eq__'),
+        var comp = comp = function(x){return $B.rich_comp("__eq__", other, x)},
             it = $RangeDict.__iter__(self),
             _next = $RangeIterator.$dict.__next__,
             nb = 0

--- a/www/src/py_set.js
+++ b/www/src/py_set.js
@@ -61,7 +61,7 @@ $SetDict.__contains__ = function(self,item){
     }
     
     for(var i=0, _len_i = self.$items.length; i < _len_i;i++){
-        if(_b_.getattr(self.$items[i],'__eq__')(item)) return true
+        if($B.rich_comp("__eq__", self.$items[i], item)) return true
     }
     return false
 
@@ -295,7 +295,7 @@ $SetDict.add = function(){
         }
         return $N
     }
-    var cfunc = _b_.getattr(item,'__eq__')
+    var cfunc = function(other){return $B.rich_comp("__eq__", item, other)}
     for(var i=0, _len_i = self.$items.length; i < _len_i;i++){
         if(cfunc(self.$items[i])) return
     }
@@ -339,7 +339,7 @@ $SetDict.difference_update = function(self){
                   } 
                } else {
                   for (var j=0; j < self.$items.length; j++) {
-                    if (_b_.getattr(self.$items[j], '__eq__')(item)) {
+                    if($B.rich_comp("__eq__", self.$items[j], item)){
                       self.$items.splice(j,1)
                     }
                   }
@@ -375,7 +375,7 @@ $SetDict.intersection_update = function(){
             }else{
               var found = false
               for(var k=0;!found && k < s.$items.length;k++){
-                if(_b_.getattr(s.$items[k], '__eq__')(_item)){found=true}
+                if($B.rich_comp("__eq__", s.$items[k], _item)){found=true}
               }
               if(!found){remove.push(j)}
            }
@@ -413,7 +413,7 @@ $SetDict.remove = function(self,item){
        return $N
     }
     for(var i=0, _len_i = self.$items.length; i < _len_i;i++){
-        if(_b_.getattr(self.$items[i],'__eq__')(item)){
+        if($B.rich_comp("__eq__", self.$items[i], item)){
             self.$items.splice(i,1)
             return $N
         }
@@ -439,7 +439,7 @@ $SetDict.symmetric_difference_update = function(self, s){
            } else {
               var found = false
               for (var j=0; !found && j < self.$items.length; j++) {
-                if (_b_.getattr(self.$items[j], '__eq__')(item)) {
+                if($B.rich_comp("__eq__", self.$items[j], item)){
                   remove.push(j)
                   found = true
                 }

--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -524,12 +524,6 @@ $B.$type.__repr__ = $B.$type.__str__ = function(self){
 $B.$type.__getattribute__=function(klass, attr, metaclassed){
 
     switch(attr) {
-      case '__eq__':
-        return method_wrapper(attr, klass,
-            function(other){return klass.$factory===other})
-      case '__ne__':
-        return method_wrapper(attr, klass,
-            function(other){return klass.$factory!==other})
       case '__class__':
         return klass.__class__.$factory
       case '__doc__':

--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -678,7 +678,7 @@ $B.$is_member = function(item,_set){
         while(1){
             try{
                 var elt = _b_.next(_iter)
-                if(_b_.getattr(elt,"__eq__")(item)) return true
+                if($B.rich_comp("__eq__", elt, item)) return true
             }catch(err){
                 if(err.__name__=="StopIteration"){
                     $B.current_exception = ce
@@ -700,7 +700,7 @@ $B.$is_member = function(item,_set){
             i++
             try{
                 var elt = f(i)
-                if(_b_.getattr(elt,"__eq__")(item)) return true
+                if($B.rich_comp("__eq__", elt, item)) return true
             }catch(err){
                 if(err.__name__=='IndexError') return false
                 throw err
@@ -1347,6 +1347,27 @@ $B.rich_comp = function(op, x, y){
         }
     }
     var res, rev_op, compared = false
+
+    if(x.__class__ && x.__class__.$factory === $B.$type.$factory && y.__class__ && y.__class__.$factory === $B.$type.$factory) {
+        if ( op == '__eq__') {
+            return (x === y || x.$factory === y || y.$factory === x)
+        } else if ( op == '__ne__') {
+            return !(x === y || x.$factory === y || y.$factory === x)
+        } else {
+            throw _b_.TypeError("'"+op+"' not supported between types")
+        }
+
+    } else if (x.__class__ && x.__class__.$factory === $B.$type.$factory ) {
+        rev_op = reversed_op[op] || op
+        res = _b_.getattr(y, rev_op)(x)
+        if ( res !== _b_.NotImplemented ) return res
+        else return False
+    } else if (y.__class__ && y.__class__.$factory === $B.$type.$factory ) {
+        res = _b_.getattr(y, op)(x)
+        if ( res !== _b_.NotImplemented ) return res
+        else return False
+    }
+
     if(x.__class__ && y.__class__){
         // cf issue #600 and
         // https://docs.python.org/3/reference/datamodel.html :

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1629,6 +1629,16 @@ try:
 except NameError:
     pass
 
+
+# issue 749
+assert float.__eq__(1.5, 1.5)
+assert float.__eq__(1.0, 1)
+assert not float.__eq__(1, 0)
+assert int.__eq__(1, 1)
+assert not int.__eq__(1, 0)
+
+
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
The `__eq__` method of a class should not be used when comparing two
classes (it should only be used when comparing instances of the class).
This patch replaces instances of

```javascript
_b_.getattr(objA, '__eq__')(objB)
```

which were used to test equality of `objA`, `objB` with

```javascript
$B.rich_comp("__eq__", objA, objB)
```

which is modified to properly handle the case when `objA` and `objB` are
types.