### PR TITLE
Fixes #761 : instead of __str__ an object's __repr__ is invoked when …

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -104,7 +104,7 @@ $ObjectDict.__format__ = function(){
     var $ = $B.args('__format__', 2, {self:null, spec:null},
         ['self', 'spec'], arguments, {}, null, null)
     if($.spec!==''){throw _b_.TypeError("non-empty format string passed to object.__format__")}
-    return _b_.getattr($.self, '__repr__')()
+    return _b_.getattr($.self, '__str__')()
 }
 
 $ObjectDict.__ge__ = function(){return _b_.NotImplemented}

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1685,6 +1685,13 @@ class B(A):
 b = B()
 assert str(b) == "an A"
 
+# issue 761
+class A:
+    def __str__(self):
+        return 'an A'
+
+assert '{0}'.format(A()) == 'an A'
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================

--- a/www/tests/test_string_format.py
+++ b/www/tests/test_string_format.py
@@ -64,6 +64,12 @@ import datetime
 d = datetime.datetime(2010, 7, 4, 12, 15, 58)
 assert '{:%Y-%m-%d %H:%M:%S}'.format(d) == '2010-07-04 12:15:58'
 
+# format objects
+class A:
+    def __str__(self):
+        return 'an A'
+assert '{}'.format(A()) == 'an A'
+
 ########################
 ## OLD STYLE FORMAT   ##
 ## ie, "%xxx" % value ##
@@ -216,7 +222,7 @@ assert int(x, 16) == 3232235521
 
 width = 5
 results = []
-for num in range(5,12): 
+for num in range(5,12):
     line = []
     for base in 'dXob':
         line.append('{0:{width}{base}}'.format(num, base=base, width=width))


### PR DESCRIPTION
…passed into a formatting string (when no conversion flag is specified)