### PR TITLE
Replace usage of self with window

### DIFF
--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -4,7 +4,7 @@ var __BRYTHON__=__BRYTHON__ || {}  // global object with brython built-ins
 
 // Detect whether we are in a Web Worker
 var isWebWorker = ('undefined' !== typeof WorkerGlobalScope) && ("function" === typeof importScripts) && (navigator instanceof WorkerNavigator)
-var _window = self;
+var _window = window;
 
 
 var $path

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -4,14 +4,14 @@
             mod[attr] = data[attr]
         }
     }
-    var _window = self;
+    var _window = window;
     var modules = {}
     var browser = {
         $package: true,
         $is_package: true,
         __package__:'browser',
         __file__:$B.brython_path.replace(/\/*$/g,'')+'/Lib/browser/__init__.py',
-        console:$B.JSObject(self.console),
+        console:$B.JSObject(window.console),
         win: $B.win,
         $$window: $B.win,
     }

--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -14,7 +14,7 @@ Number.isSafeInteger = Number.isSafeInteger || function (value) {
 
 var js,$pos,res,$op
 var _b_ = $B.builtins
-var _window = self;
+var _window = window;
 var isWebWorker = $B.isa_web_worker = ('undefined' !== typeof WorkerGlobalScope) && ("function" === typeof importScripts) && (navigator instanceof WorkerNavigator);
 
 


### PR DESCRIPTION
This is a **proposal**.

A very limited amount of places in the code use `self` rather than `window`. This seems to bring no obvious advantage (for this humble beginner in the obscure art of Javascripting), hence the proposed changes to use `window`.

Reference for `self`: https://developer.mozilla.org/en-US/docs/Web/API/Window/self

There may, of course, be very good and valid reasons for using `self`. In that case, please do disregard and close this pull-request.