### PR TITLE
Replace _ (python allowed) with - (not allowed as identifier in python)

### DIFF
--- a/www/src/py_dom.js
+++ b/www/src/py_dom.js
@@ -342,6 +342,7 @@ $StyleDict.__setattr__ = function(self,attr,value){
         self.js.cssFloat = value
         self.js.styleFloat = value
     }else{
+        attr = attr.replace('_', '-')
         switch(attr) {
           case 'top':
           case 'left':


### PR DESCRIPTION
When setting a the *style* a DOMNode, one can do:

```
node.style.padding = '16px'
```

but this will obviously fail (because `-` is not an allowed character in Python identifiers)

```
node.style.padding-top = '8px'
```

forcing to adopt a non-idiomatic (compared to the above) approach

```
setattr(node.style, 'padding-top', '8px')
```

with the pull request one can now do:

```
node.style.padding_top = `8px`
```

et voilá!