### PR TITLE
fix: Evaluate iterable expression of for cycles once (Fixes #801)

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -2906,14 +2906,15 @@ function $ForExpr(context){
         var new_node = new $Node()
         new_node.line_num = $get_node(this).line_num
         var it_js = iterable.to_js()
-        var js = '$locals["$next' + num + '"]' + ' = $B.$getattr($B.$iter(' +
-            it_js + '),"__next__")'
+            iterable_name = '$iter'+num
+            js = 'var ' + iterable_name + ' = ' + it_js + ';' +
+                 '$locals["$next' + num + '"]' + ' = $B.$getattr($B.$iter('+iterable_name+'),"__next__")'
         new $NodeJSCtx(new_node,js)
         new_nodes[pos++] = new_node
 
         // Line to store the length of the iterator
-        var js = 'if(isinstance(' + it_js + ', dict)){$locals.$len_func' +
-            num + ' = $B.$getattr(' + it_js + ', "__len__"); $locals.$len' +
+        var js = 'if(isinstance(' + iterable_name + ', dict)){$locals.$len_func' +
+            num + ' = $B.$getattr(' + iterable_name + ', "__len__"); $locals.$len' +
             num + ' = $locals.$len_func' + num + '()}else{$locals.$len' +
             num + ' = null}'
         new_nodes[pos++] = $NodeJS(js)

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1680,6 +1680,24 @@ exec(def_str, globals())
 
 assert hello() == "Hello!"
 
+# issue 801
+
+
+class L:
+    def __init__(self):
+        self._called = 0
+
+    def get_list(self):
+        self._called += 1
+        return [0]
+
+l = L()
+
+for i in l.get_list():
+    pass
+
+assert l._called == 1
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
The javascript code generated for

```python
for x in expr:
    ...
```

evaluates the expression `expr` multiple times. This commit changes the
generated code so that it evaluates the expression `expr` only once.