### PR TITLE
Fix bug in jsobjtopyobj() for kwarg objects

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -92,6 +92,10 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj) {
        return _b_.float.$factory(jsobj)
     }
 
+    if(jsobj.$nat === 'kw') {
+        return jsobj
+    }
+
     return JSObject.$factory(jsobj)
 }
 

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1792,6 +1792,22 @@ def f():
 
 assert f.__code__.co_code.startswith("function f")
 
+# Regression introduced in 6888c6d67b3d5b44905a09fa427a84bef2c7b304
+class A:
+    pass
+
+global_x = None
+def target(x=None):
+    global global_x
+    global_x = x
+
+js_obj_dict = A().__dict__
+js_obj_dict['target_key'] = target
+js_obj_dict['target_key'](x='hello')
+
+assert global_x == 'hello'
+
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
6888c6d67b3d5b44905a09fa427a84bef2c7b304 introduced a bug that affected Python functions that take keyword arguments if the Python function was used after being called with `pyobj2jsobj()`. The way that our code ran into this situation was by storing a Python function into the value of a dictionary that was created by using a class's `__dict__` attribute. Therefore, that's what I used for the test case. If there is a less roundabout way of having `pyobj2jsobj()` be called on a function, I'd prefer to use that for the test case since that is what is really being tested, not the implementation of `__dict__` or the special handling for `dict.$jsobj` objects.