### PR TITLE
Fix DOMNode.addEventListener so that it can take extra args after the…

### DIFF
--- a/www/src/py_dom.js
+++ b/www/src/py_dom.js
@@ -632,10 +632,10 @@ DOMNode.__getattribute__ = function(self, attr){
                     for(var i = 0; i < arguments.length; i++){
                         var arg = arguments[i]
                         if(typeof arg == "function"){
-                            var f1 = function(){
-                                try{return arg.apply(null, arguments)}
+                            var f1 = function(dest_fn) { return function(){
+                                try{return dest_fn.apply(null, arguments)}
                                 catch(err){
-                                    console.log(arg, typeof arg, err)
+                                    console.log(dest_fn, typeof dest_fn, err)
                                     if(err.__class__ !== undefined){
                                         var msg = _b_.getattr(err, 'info') +
                                             '\n' + err.__class__.__name__
@@ -648,7 +648,7 @@ DOMNode.__getattribute__ = function(self, attr){
                                     }
                                     throw err
                                 }
-                            }
+                            }}(arg)
                             args[pos++] = f1
                         }
                         else if(isinstance(arg, JSObject)){

--- a/www/tests/dom.py
+++ b/www/tests/dom.py
@@ -27,3 +27,15 @@ assert x.mybool is False
 
 y = A(False)
 assert y.mybool == False
+
+# test setting a callback function
+f_called = False
+def f(*args, **kwargs):
+	global f_called
+	f_called = True
+
+element = document.getElementById('dom-test-element-id')
+# test passing an additional argument after the callback f
+element.addEventListener('click', f, True)
+element.click()
+assert f_called

--- a/www/tests/index.html
+++ b/www/tests/index.html
@@ -49,6 +49,9 @@
 <script src="dom_js_tests.js"></script>
 <script src="jsobj_tests.js"></script>
 
+<!-- HTML needed to run tests included in dom.py -->
+<div id="dom-test-element-id"/>
+
 <script type="text/javascript" src="../src/brython_stdlib.js"></script>
 
 <script type="text/python3" id="tests">

--- a/www/tests/qunit/run_tests.html
+++ b/www/tests/qunit/run_tests.html
@@ -59,10 +59,12 @@
     <script type="text/javascript" src="../../src/py_import_hooks.js"></script>
     <script type="text/javascript" src="../../src/async.js"></script>
 
-<!-- Javascript code needed to run tests included in dom.py -->
+    <!-- Javascript code needed to run tests included in dom.py -->
     <script type="text/javascript" src="../dom_js_tests.js"></script>
+    <!-- HTML needed to run tests included in dom.py -->
+    <div id="dom-test-element-id"></div>
 
-<!-- Javascript code needed to run JSObject tests -->
+    <!-- Javascript code needed to run JSObject tests -->
     <script type="text/javascript" src="../jsobj_tests.js"></script>
 
 


### PR DESCRIPTION
… listener function

The call to `addEventListener` in the test that I added is a special case of a more general situation, which is any function that is an attribute of a DOM node that is passed a callback function.

(This bug was introduced in 58a8a89)