### PR TITLE
Buffer console output by default (improves print performance).

### DIFF
--- a/www/tests/console.py
+++ b/www/tests/console.py
@@ -50,6 +50,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 """
 
+CODE_ELT = doc['code']
+
 def credits():
     print(_credits)
 credits.__repr__ = lambda:_credits
@@ -62,9 +64,17 @@ def license():
     print(_license)
 license.__repr__ = lambda:_license
 
-def write(data):
-    doc['code'].value += str(data)
 
+OUT_BUFFER = ''
+
+def write(data):
+    global OUT_BUFFER
+    OUT_BUFFER += str(data)
+
+def flush():
+    global CODE_ELT, OUT_BUFFER
+    CODE_ELT.value += OUT_BUFFER
+    OUT_BUFFER = ''
 
 sys.stdout.write = sys.stderr.write = write
 history = []
@@ -115,8 +125,10 @@ def myKeyPress(event):
         if _status == "main" or _status == "3string":
             try:
                 _ = editor_ns['_'] = eval(currentLine, editor_ns)
+                flush()
                 if _ is not None:
                     write(repr(_)+'\n')
+                flush()
                 doc['code'].value += '>>> '
                 _status = "main"
             except IndentationError:
@@ -132,6 +144,7 @@ def myKeyPress(event):
                         exec(currentLine, editor_ns)
                     except:
                         traceback.print_exc()
+                    flush()
                     doc['code'].value += '>>> '
                     _status = "main"
                 elif str(msg) == 'decorator expects function':
@@ -139,10 +152,12 @@ def myKeyPress(event):
                     _status = "block"
                 else:
                     traceback.print_exc()
+                    flush()
                     doc['code'].value += '>>> '
                     _status = "main"
             except:
                 traceback.print_exc()
+                flush()
                 doc['code'].value += '>>> '
                 _status = "main"
         elif currentLine == "":  # end of block
@@ -157,6 +172,7 @@ def myKeyPress(event):
                     print(repr(_))
             except:
                 traceback.print_exc()
+            flush()
             doc['code'].value += '>>> '
         else:
             doc['code'].value += '... '

--- a/www/tests/editor.py
+++ b/www/tests/editor.py
@@ -55,16 +55,21 @@ def reset_src_area():
         editor.value = 'for i in range(10):\n\tprint(i)'
 
 class cOutput:
+    def __init__(self):
+        self.cons = doc["console"]
+        self.buf = ''
 
     def write(self, data):
-        doc["console"].value += str(data)
+        self.buf += str(data)
 
     def flush(self):
-        pass
+        self.cons.value += self.buf
+        self.buf = ''
 
 if "console" in doc:
-    sys.stdout = cOutput()
-    sys.stderr = cOutput()
+    cOut = cOutput()
+    sys.stdout = cOut
+    sys.stderr = cOut
 
 def to_str(xx):
     return str(xx)
@@ -99,6 +104,7 @@ def run(*args):
     except Exception as exc:
         traceback.print_exc(file=sys.stderr)
         state = 0
+    sys.stdout.flush()
     output = doc["console"].value
 
     print('<completed in %6.2f ms>' % ((time.perf_counter() - t0) * 1000.0))


### PR DESCRIPTION
Since dom changes only become visible after the script executes, there's
no reason to run `doc['console'].value += data` for every `print(data)`.
We can postpone this to just after the script executes. Also, no need to
lookup the console element by id every time, do it just once and store
it in a global variable.

This should address https://groups.google.com/forum/#!topic/brython/2vrfagT4wKg