### PR TITLE
Make functions hashable

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -919,7 +919,8 @@ function hash(obj){
     if(isinstance(obj, _b_.int)){return obj.valueOf()}
     if(isinstance(obj, _b_.bool)){return _b_.int.$factory(obj)}
     if(obj.__class__ === $B.$factory || obj.$is_class ||
-            obj.__class__ === _b_.type){
+            obj.__class__ === _b_.type ||
+            obj.__class__ === $B.Function){
         return obj.__hashvalue__ = $B.$py_next_hash--
     }
     if(obj.__hash__ !== undefined) {
@@ -1091,7 +1092,7 @@ function isinstance(obj,arg){
     }
 
     // Search __instancecheck__ on arg
- 
+
     var hook = getattr(arg, '__instancecheck__', _b_.None)
     if(hook!==_b_.None){
         return hook(obj)

--- a/www/tests/test_dict.py
+++ b/www/tests/test_dict.py
@@ -60,5 +60,17 @@ assert window.test_null('python_none')
 # Test setdefault
 assert pyobj.setdefault('default') is None
 
+# Test that functions are hashable
+def f(): return 5
+def g(): return 6
+
+d = {
+    f: 1,
+    g: 2,
+}
+
+assert d[f] == 1
+assert d[g] == 2
+assert hash(f) != hash(g)
 
 print("passed all tests..")


### PR DESCRIPTION
I think that this is the correct behavior--every Python function is unique, so each should have its own hash value. I can't find any documentation to prove it, though. What do you think?
