### PR TITLE
Ignore reserved attributes that are set in module implementations

### DIFF
--- a/www/src/py_import.js
+++ b/www/src/py_import.js
@@ -172,6 +172,16 @@ function run_js(module_contents, path, _module){
     }
 
     if(_module !== undefined){
+        // Don't let module implementations set the value of these reserved attributes
+        delete $module.__cached__
+        delete $module.__class__
+        delete $module.__file__
+        delete $module.__loader__
+        delete $module.__name__
+        delete $module.__package__
+        delete $module.__path__
+        delete $module.__spec__
+
         // FIXME : This might not be efficient . Refactor js modules instead.
         // Overwrite original module object . Needed e.g. for reload()
         for(var attr in $module){_module[attr] = $module[attr]}

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1821,6 +1821,11 @@ for i in range(len(a) - 1):
     assert a[i] <= a[i+1]
 
 
+# Issue 838
+import sys
+import random
+assert type(random) == type(sys)
+
 
 # ==========================================
 # Finally, report that all tests have passed


### PR DESCRIPTION
Fixes #838 

Perhaps this list of reserved attributes could be specified in a cleaner way?