### PR TITLE
fix: Implement __len__ on editor/console stderr+stdout (fixes #841)

### DIFF
--- a/www/tests/console.py
+++ b/www/tests/console.py
@@ -77,6 +77,8 @@ def flush():
     OUT_BUFFER = ''
 
 sys.stdout.write = sys.stderr.write = write
+sys.stdout.__len__ = sys.stderr.__len__ = lambda: len(OUT_BUFFER)
+
 history = []
 current = 0
 _status = "main"  # or "block" if typing inside a block

--- a/www/tests/editor.py
+++ b/www/tests/editor.py
@@ -54,7 +54,10 @@ def reset_src_area():
     else:
         editor.value = 'for i in range(10):\n\tprint(i)'
 
+
 class cOutput:
+    encoding = 'utf-8'
+
     def __init__(self):
         self.cons = doc["console"]
         self.buf = ''
@@ -66,10 +69,14 @@ class cOutput:
         self.cons.value += self.buf
         self.buf = ''
 
+    def __len__(self):
+        return len(self.buf)
+
 if "console" in doc:
     cOut = cOutput()
     sys.stdout = cOut
     sys.stderr = cOut
+
 
 def to_str(xx):
     return str(xx)


### PR DESCRIPTION
Unfortunately, logging still fails mysteriously. It seems that setting `record.message` on line 547 of logging/__init__.py doesn't make it available in `record.__dict__` leading to an error on line 365 of the
same file.