### PR TITLE
Travis CI: upgrade Chrome and skip Chromium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: javascript
 addons:
     chrome: stable
     firefox: "59.0"
-    firefox: latest-beta
 
 cache:
   directories:
@@ -15,6 +14,8 @@ before_install:
   - wget -O qunit/qunit-1.18.0.js  http://code.jquery.com/qunit/qunit-1.18.0.js
   - npm install testem
   - ./node_modules/.bin/testem launchers
+  # A newer version of libnss3 is needed for the latest Chrome version
+  - apt-get --only-upgrade install libnss3
 
 before_script:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: javascript
 
 addons:
@@ -15,7 +17,7 @@ before_install:
   - npm install testem
   - ./node_modules/.bin/testem launchers
   # A newer version of libnss3 is needed for the latest Chrome version
-  - apt-get --only-upgrade install libnss3
+  - sudo apt-get --only-upgrade install libnss3
 
 before_script:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - wget -O qunit/qunit-1.18.0.css http://code.jquery.com/qunit/qunit-1.18.0.css
   - wget -O qunit/qunit-1.18.0.js  http://code.jquery.com/qunit/qunit-1.18.0.js
   - npm install testem
+  - ./node_modules/.bin/testem launchers
 
 before_script:
   - export DISPLAY=:99.0
@@ -21,6 +22,6 @@ before_script:
   # - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
 
 script:
-  - ./node_modules/.bin/testem --skip PhantomJS -t www/tests/qunit/run_tests.html ci
+  - ./node_modules/.bin/testem --skip PhantomJS,Chromium -t www/tests/qunit/run_tests.html ci
   #- phantomjs phantomjs/examples/run-qunit.js www/tests/qunit/run_tests.html
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: javascript
 
 addons:
+    chrome: stable
     firefox: "59.0"
+    firefox: latest-beta
 
 cache:
   directories:


### PR DESCRIPTION
The build for #845 failed because of a timeout error running the tests with Chromium. I checked the previous PR build in Travis and it didn't run the tests on Chromium, which made me think that some configuration changed on the Travis machine. Not sure if that is correct!

Then the build for this PR (@ c61c865) failed when running the tests with Chrome 52. It looks like we were previously running with 51. Perhaps this was also due to a change on Travis? I modified the Travis config to use the latest stable Chrome (Chrome 52 was released in 2016), and now the tests pass again.