### PR TITLE
Fix regression that removed function name from stack traces

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -2424,7 +2424,7 @@ var $DefCtx = $B.parser.$DefCtx = function(context){
         // Push id in frames stack
         var enter_frame_nodes = [
             $NodeJS('var $top_frame = [$local_name, $locals,' +
-                '"' + global_scope.id + '", ' + global_ns + ']'),
+                '"' + global_scope.id + '", ' + global_ns + ', ' + name + ']'),
             $NodeJS('$B.frames_stack.push($top_frame)'),
             $NodeJS('var $stack_length = $B.frames_stack.length')
         ]
@@ -4016,7 +4016,7 @@ var $IdCtx = $B.parser.$IdCtx = function(context,value){
                     while(sc !== scope){up++; sc = sc.parent_block}
                     var scope_name = "$B.frames_stack[$B.frames_stack.length-1-" +
                         up + "][1]"
-                    val = '$B.$check_def_free1("' + val + '", "' + 
+                    val = '$B.$check_def_free1("' + val + '", "' +
                         scope.id.replace(/\./g, "_") + '")'
                 }else{
                     val = '$B.$check_def_free("' + val + '",' + scope_ns +

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -1916,6 +1916,7 @@ except Exception:
     exception_info = tb.format_exc()
     assert 'f()' in exception_info
     assert '1 / 0' in exception_info
+    assert ', in f' in exception_info
 
 # PEP 448
 assert dict(**{'x': 1}, y=2, **{'z': 3}) == {"x": 1, "y": 2, "z": 3}


### PR DESCRIPTION
4ec774359d92ceae065151b9c9280211ccc947da unintentionally (?) removed the `name` parameter from stack frames.