### PR TITLE
(#871) write traceback to sys.stderr

### DIFF
--- a/www/src/Lib/traceback.py
+++ b/www/src/Lib/traceback.py
@@ -7,7 +7,10 @@ def _restore_current(exc):
     """
     __BRYTHON__.current_exception = exc
 
-def print_exc(file=sys.stderr):
+def print_exc(file=None):
+    """Print the last exception."""
+    if file is None:
+        file = sys.stderr
     file.write(format_exc())
 
 def format_exc(limit=None, chain=True, includeInternal=False):


### PR DESCRIPTION
Fixes #871
Problem: traceback.print_exc uses a fixed sys.stderr
Solution: use sys.stderr as it is when the call happens
More references: https://github.com/python/cpython/blob/bb8b1cb6af830b40f9be398d1e1bf8bdca772140/Lib/traceback.py#L97