### PR TITLE
Implement SRE_Pattern.sub()

### DIFF
--- a/www/src/libs/_jsre.js
+++ b/www/src/libs/_jsre.js
@@ -72,9 +72,17 @@ var $module=(function($B){
     $SRE_PatternDict.search = function(self, string){
         return obj.search(self.pattern, string, self.flags)
     }
+    $SRE_PatternDict.sub = function(self,repl,string){
+        return obj.sub(self.pattern,repl,string,self.flags)
+    }
+    // TODO: groups
+    // TODO: groupindex
     function normflags(flags){
         return ((flags & obj.I)? 'i' : '') + ((flags & obj.M)? 'm' : '');
     }
+    // TODO: fullmatch()
+    // TODO: split()
+    // TODO: subn()
     obj.compile = function(pattern, flags){
         return {
             __class__: $SRE_PatternDict,
@@ -213,8 +221,9 @@ var $module=(function($B){
             var $repl1 = function(){
                 var mo = Object()
                 mo.string = arguments[arguments.length - 1]
+                var matched = arguments[0];
                 var start = arguments[arguments.length - 2]
-                var end = start + arguments[0].length
+                var end = start + matched.length
                 mo.start = function(){return start}
                 mo.end = function(){return end}
                 groups = []
@@ -229,6 +238,10 @@ var $module=(function($B){
                         else{res.push(groups[i])}
                     }
                     return res
+                }
+                mo.group = function(i){
+                    if(i==0){return matched}
+                    return groups[i-1]
                 }
                 return repl(JSObject.$factory(mo))
             }

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -2001,6 +2001,31 @@ for _ in range(2):
         pass
 
 
+# issue 901 : _jsre's SRE_Pattern lacking methods: .sub(), .subn(), .split(), and .fullmatch() 
+import _jsre as re
+
+regex = re.compile('a|b')
+
+# These methods work!
+assert regex.match('ab') is not None
+assert regex.search(' ab') is not None
+assert regex.findall('ab') == ['a', 'b']
+
+# Broken: .finditer()
+assert [m.group(0) for m in regex.finditer('ab')] == ['a', 'b']
+
+# Missing: .fullmatch()
+assert regex.fullmatch('b') is not None
+
+def switch(m):
+    return 'a' if m.groups(0) == 'b' else 'b'
+
+# Missing: .sub()
+assert regex.sub(switch, 'ba') == 'ab'
+
+# Missing: .subn()
+assert regex.subn(switch, 'ba', 1) == ('aa', 1)
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -2001,7 +2001,7 @@ for _ in range(2):
         pass
 
 
-# issue 901 : _jsre's SRE_Pattern lacking methods: .sub(), .subn(), .split(), and .fullmatch() 
+# issue 901 : _jsre's SRE_Pattern lacking methods: .sub(), .subn(), .split(), and .fullmatch()
 import _jsre as re
 
 regex = re.compile('a|b')
@@ -2011,20 +2011,23 @@ assert regex.match('ab') is not None
 assert regex.search(' ab') is not None
 assert regex.findall('ab') == ['a', 'b']
 
-# Broken: .finditer()
-assert [m.group(0) for m in regex.finditer('ab')] == ['a', 'b']
-
-# Missing: .fullmatch()
-assert regex.fullmatch('b') is not None
-
 def switch(m):
-    return 'a' if m.groups(0) == 'b' else 'b'
+    return 'a' if m.group(0) == 'b' else 'b'
 
 # Missing: .sub()
 assert regex.sub(switch, 'ba') == 'ab'
 
+# Missing: .fullmatch()
+# assert regex.fullmatch('b') is not None
+
+# Missing: .split()
+#assert regex.split('cacbca', maxsplit=2) == ['c', 'c', 'ca']
+
 # Missing: .subn()
-assert regex.subn(switch, 'ba', 1) == ('aa', 1)
+#assert regex.subn(switch, 'ba') == ('ab', 2)
+
+# Broken: .finditer()
+#assert [m.group(0) for m in regex.finditer('ab')] == ['a', 'b']
 
 # ==========================================
 # Finally, report that all tests have passed


### PR DESCRIPTION
I was going to try to implement all the missing methods as mentioned in #901, but then realized that it was going to be more work than I anticipated! So I'm starting small with this PR just to add the `.sub()` method. I also implemented the `.group()` method for match objects passed to the replacement callback of `.sub()` because there was previously no way of getting the matched string from inside the replacement callback!