### PR TITLE
Improve error message for comparing with None

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -66,7 +66,7 @@ for(var $op in $B.$comps){ // None is not orderable with any type
       case 'le':
       case 'lt':
         NoneType['__' + key + '__'] = (function(op){
-            return function(other){
+            return function(self, other){
             throw _b_.TypeError.$factory("unorderable types: NoneType() " +
                 op + " " + $B.get_class(other).__name__ + "()")}
         })($op)


### PR DESCRIPTION
Old behavior:

```
>>> 3 < None

TypeError: unorderable types: NoneType() < NoneType()
```

New behavior:

```
>>> 3 < None

TypeError: unorderable types: NoneType() < int()
```

This is still incorrect because the order of the arguments was switched. It is an improvement though.