### PR TITLE
Use 'en' locale if no other is available

### DIFF
--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -93,7 +93,7 @@ $B.__setattr__ = function(attr,value){
 
 // system language ( _not_ the one set in browser settings)
 // cf http://stackoverflow.com/questions/1043339/javascript-for-detecting-browser-language-preference
-$B.language = _window.navigator.userLanguage || _window.navigator.language || 'en';
+$B.language = _window.navigator.userLanguage || _window.navigator.language || 'en'
 
 $B.locale = $B.language.substr(0, 2) // can be reset by locale.setlocale
 

--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -93,7 +93,7 @@ $B.__setattr__ = function(attr,value){
 
 // system language ( _not_ the one set in browser settings)
 // cf http://stackoverflow.com/questions/1043339/javascript-for-detecting-browser-language-preference
-$B.language = _window.navigator.userLanguage || _window.navigator.language
+$B.language = _window.navigator.userLanguage || _window.navigator.language || 'en';
 
 $B.locale = $B.language.substr(0, 2) // can be reset by locale.setlocale
 


### PR DESCRIPTION
Currently line 98 of brython_builtins.js raises an exception if you load Brython in a web worker on Chrome because `$B.language` is undefined. 

This is not the best fix, but it looks like Chrome's self.navigator object doesn't contain language info, so I'm not sure what else to do: https://bugs.chromium.org/p/chromium/issues/detail?id=276159