### PR TITLE
Fix minifier so that exception.__context__ is preserved

### DIFF
--- a/scripts/make_dist.py
+++ b/scripts/make_dist.py
@@ -98,7 +98,7 @@ def run():
         src_size += len(src)
         res += javascript_minifier.minify(src)
 
-    res = res.replace('context', 'C')
+    res = re.sub(r'\bcontext\b', 'C', res)
 
     with open(abs_path('brython.js'), 'w') as out:
         out.write(res)


### PR DESCRIPTION
This line in make_dist.py:

https://github.com/brython-dev/brython/blob/master/scripts/make_dist.py#L101

used to mangle this line and the following one in py_exceptions.js:

https://github.com/brython-dev/brython/blob/master/www/src/py_exceptions.js#L381

The generated code created exception objects with `__C__` and `__suppress_C__` properties instead of `__context__` and `__suppress_context__` properties.

What do you think of modifying the testem tests to use brython.js and brython_stdlib.js instead of the individual source files so that errors like this in the build script would be caught by the tests? It would mean that the development workflow would have to have an additional step where you run make_dist.py before running the unit tests...