### PR TITLE
Never allow stack.f_code.co_filename to be undefined

### DIFF
--- a/www/src/py_exceptions.js
+++ b/www/src/py_exceptions.js
@@ -209,12 +209,7 @@ var frame = $B.make_class("frame",
                 co_filename: filename // idem
             }
             if(res.f_code.co_filename === undefined){
-                if(_frame[3].$src){
-                    res.f_code.co_filename = "<string>"
-                    //$B.file_cache[res.f_code.co_filename] = _frame[3].$src
-                }else{
-                    console.log("pas de src")
-                }
+              res.f_code.co_filename = "<string>"
             }
         }
         return res


### PR DESCRIPTION
I unfortunately have yet to be able to reproduce this bug with a small amount of code, but with some combination of exec, lambda, and py->js compilation that our application does, I can generate an exception that triggers the "pas de src" warning and then crashes when I call `traceback.format_exc()`. 