### PR TITLE
Fix py_bytes.js for Safari 10

### DIFF
--- a/www/src/py_bytes.js
+++ b/www/src/py_bytes.js
@@ -965,7 +965,7 @@ bytes.expandtabs = function() {
         ['self', 'tabsize'], arguments, {tabsize: 8}, null, null)
 
     var tab_spaces = []
-    for (var i = 0; i < $.tabsize; ++i)
+    for (let i = 0; i < $.tabsize; ++i)
         tab_spaces.push(32)
 
     var buffer = $.self.source.slice()


### PR DESCRIPTION
When this function is run on Safari 10, it triggers this error: "Cannot declare a let variable twice"