### PR TITLE
Travis CI: Stop the build if Python syntax errors are detected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ cache:
 
 matrix:
   include:
-    - python: 3.7
+    - language: javascript
+    - language: python
+      python: 3.7
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-      language: python
       before_install: pip install --upgrade pip
       before_script: pip install flake8
       script:
-        - EXCLUDE=.git,www/src/Lib/test/badsyntax_3131.py
+        - EXCLUDE=./.*,www/src/Lib/test/badsyntax_3131.py
         # stop the build if there are Python syntax errors
         - flake8 . --exclude=$EXCLUDE --exit-zero --select=E999 --show-source --statistics
 


### PR DESCRIPTION
Create a parallel built to detect Python syntax errors using [flake8](http://flake8.pycqa.org) running on Python 3.7.

[flake8](http://flake8.pycqa.org) testing of https://github.com/brython-dev/brython on Python 3.7

$ __flake8 . --exclude=$EXCLUDE --exit-zero --select=E999 --show-source --statistics__
```
./www/speed/benchmarks/spectral-norm.py:31:20: E999 SyntaxError: invalid syntax
def part_A_times_u((i,u)):
                   ^
./www/benchmarks/performance/testlist.py:3:26: E999 SyntaxError: invalid syntax
{'name': 'bm_call_simple': 'descr': 'Test the performance of function calls', 'num_runs': 1},
                         ^
2     E999 SyntaxError: invalid syntax
```

Note: __--exit-zero__ should be remove once these syntax errors are fixed to prevent regressions.