### PR TITLE
spectral-norm.py: Fix Python 3 syntax error in function calls

### DIFF
--- a/www/speed/benchmarks/spectral-norm.py
+++ b/www/speed/benchmarks/spectral-norm.py
@@ -1,64 +1,63 @@
 # -*- coding: utf-8 -*-
 # The Computer Language Benchmarks Game
-# http://shootout.alioth.debian.org/
+# https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
 # Contributed by Sebastien Loisel
 # Fixed by Isaac Gouy
 # Sped up by Josh Goldfoot
 # Dirtily sped up by Simon Descarpentries
 # Concurrency by Jason Stitt
+# 2to3
 
+from multiprocessing import Pool
 from math            import sqrt
-from itertools       import izip
-import time
-import util
-import itertools
-import optparse
 
-def eval_A (i, j):
+from sys             import argv
+
+def eval_A(i, j):
     return 1.0 / ((i + j) * (i + j + 1) / 2 + i + 1)
 
-def eval_A_times_u (u):
+def eval_A_times_u(u):
     args = ((i,u) for i in range(len(u)))
-    return map(part_A_times_u, args)
+    return pool.map(part_A_times_u, args)
 
-def eval_At_times_u (u):
+def eval_At_times_u(u):
     args = ((i,u) for i in range(len(u)))
-    return map(part_At_times_u, args)
+    return pool.map(part_At_times_u, args)
 
-def eval_AtA_times_u (u):
+def eval_AtA_times_u(u):
     return eval_At_times_u (eval_A_times_u (u))
 
-def part_A_times_u((i,u)):
+def part_A_times_u(i_and_u):
+    (i,u) = i_and_u
     partial_sum = 0
     for j, u_j in enumerate(u):
         partial_sum += eval_A (i, j) * u_j
     return partial_sum
 
-def part_At_times_u((i,u)):
+def part_At_times_u(i_and_u):
+    (i,u) = i_and_u
     partial_sum = 0
     for j, u_j in enumerate(u):
         partial_sum += eval_A (j, i) * u_j
     return partial_sum
 
-DEFAULT_N = 130
+def main():
+    n = int(argv[1])
+    u = [1] * n
 
-def main(n):
-    times = []
-    for i in range(n):
-        t0 = time.time()
-        u = [1] * DEFAULT_N
+    for dummy in range (10):
+        v = eval_AtA_times_u (u)
+        u = eval_AtA_times_u (v)
 
-        for dummy in range(10):
-            v = eval_AtA_times_u (u)
-            u = eval_AtA_times_u (v)
+    vBv = vv = 0
 
-        vBv = vv = 0
+    for ue, ve in zip (u, v):
+        vBv += ue * ve
+        vv  += ve * ve
 
-        for ue, ve in izip (u, v):
-            vBv += ue * ve
-            vv  += ve * ve
-        tk = time.time()
-        times.append(tk - t0)
-    return times
+    print("%0.9f" % (sqrt(vBv/vv)))
 
-main(10)
+if __name__ == '__main__':
+    pool = Pool(processes=4)
+    main()


### PR DESCRIPTION
Python 3 treats explicit tuples in function parameters as syntax errors.  Acquired current source code from:
* https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/spectralnorm-python3-5.html