### PR TITLE
Fix typo of `__init__.py` in `import` documentation

### DIFF
--- a/www/doc/en/import.md
+++ b/www/doc/en/import.md
@@ -3,7 +3,7 @@ Implementation of _import_
 
 Like in standard Python, you can install modules or packages Python in your
 application by putting them in the root directory, or in directories with a
-file __\_\_init.py\_\___.
+file __\_\_init\_\_.py__.
 
 Note that modules must be encoded in utf-8 ; the encoding declaration at the
 top of the script is ignored.

--- a/www/doc/es/import.md
+++ b/www/doc/es/import.md
@@ -3,7 +3,7 @@ Implementación de import
 
 Como en Python estándar, puedes instalar módulos o paquetes en tu
 aplicación colocándolos en el directorio raíz o en directorios con un 
-fichero __\_\_init.py\_\___.
+fichero __\_\_init\_\_.py__.
 
 Destacar que los módulos deben ser codificados en utf-8 ; la declaración de codificación al inicio 
 del script será ignarada.

--- a/www/doc/fr/import.md
+++ b/www/doc/fr/import.md
@@ -3,7 +3,7 @@ Implémentation de _import_
 
 Vous pouvez installer des modules ou des paquetages Python dans votre
 application, en les mettant à la racine de l'application ou dans des
-répertoires comportant un fichier __\_\_init.py\_\___.
+répertoires comportant un fichier __\_\_init\_\_.py__.
 
 Noter que les modules doivent être encodés en utf-8 ; la déclaration
 d'encodage en début de module n'est pas prise en compte.


### PR DESCRIPTION
Currently `__init.py__` is written in the documentation (https://brython.info/static_doc/en/import.html) instead of `__init__.py`.