### PR TITLE
Require Python 3.7 in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ plumbum = "*"
 [packages]
 
 [requires]
-python_version = "3.5"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,24 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2692c5ecffa418e0eab3752e814b8cc513bd933ec4a41bbec4ab232d0a33d05a"
-        },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.5.2",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "4.13.0-39-generic",
-            "platform_system": "Linux",
-            "platform_version": "#44~16.04.1-Ubuntu SMP Thu Apr 5 16:43:10 UTC 2018",
-            "python_full_version": "3.5.2",
-            "python_version": "3.5",
-            "sys_platform": "linux"
+            "sha256": "95bad97a4fc0c379965626c1837c88563aad9f4d8ac4497dc1132a5cd79069ae"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.5"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -32,11 +19,11 @@
     "develop": {
         "plumbum": {
             "hashes": [
-                "sha256:4b5af076fef56fe7345b67f7fa4c79185fa64ac5bc14a9de1aa1447b58b6cbd0",
-                "sha256:d179b90a9927f91427a28c1bac2864c61342cb43ef39aa7324c7c9a96bcc23eb",
-                "sha256:e4be6200df23b03926c27fe333356408f5212182675fcbacda06ecbfa83bf863"
+                "sha256:d143f079bfb60b11e9bec09a49695ce2e55ce5ca0246877bdb0818ab7c7fc312",
+                "sha256:df96a5facf621db4a6d682bdc93afa5ed6b107a8667c73c3f0a0f0fab4217c81"
             ],
-            "version": "==1.6.6"
+            "index": "pypi",
+            "version": "==1.6.7"
         }
     }
 }


### PR DESCRIPTION
I'm not sure if anyone is using this file since @jonathanverner's change that introduced it got partially reverted. But it's useful for me, and because of the Python library upgrade, Python 3.5 no longer works to run make_dist.py. 