### PR TITLE
Fix path to z.txt in issues.py tests

### DIFF
--- a/www/tests/brython_test_utils/__init__.py
+++ b/www/tests/brython_test_utils/__init__.py
@@ -78,11 +78,13 @@ def populate_testmod_input(elem, selected=None):
                 o = html.OPTION(caption, value=filenm)
             g <= o
 
-def run(src):
+def run(src, file_path=None):
     t0 = time.perf_counter()
     msg = ''
     try:
         ns = {'__name__':'__main__'}
+        if file_path is not None:
+            ns['__file__'] = file_path
         exec(src, ns)
         state = 1
     except Exception as exc:
@@ -95,6 +97,7 @@ def run(src):
 def run_test_module(filename, base_path=''):
     if base_path and not base_path.endswith('/'):
         base_path += '/'
-    src = open(base_path + filename).read()
-    return run(src)
+    file_path = base_path + filename
+    src = open(file_path).read()
+    return run(src, file_path)
 

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -2130,11 +2130,18 @@ b2 = B()
 assert b2.show() == 8
 
 # issue 1059
-with open("z.txt", encoding="utf-8") as f:
+import os
+try:
+    issues_py_dir = os.path.dirname(__file__)
+    z_txt_path = os.path.join(issues_py_dir, "z.txt")
+except NameError:
+    z_txt_path = "z.txt"
+
+with open(z_txt_path, encoding="utf-8") as f:
     t = [line for line in f]
 assert t == ["a\n", "b\n", "c\n"]
 
-with open("z.txt", encoding="utf-8") as f:
+with open(z_txt_path, encoding="utf-8") as f:
     assert f.readlines() == t
 
 # issue 1063


### PR DESCRIPTION
This was causing a failure in the qunit-based tests. There are other errors, so the Travis build still won't pass, but this is an improvement.