### PR TITLE
Add passing test_grammar tests to CI build

### DIFF
--- a/www/src/Lib/test/mapping_tests.py
+++ b/www/src/Lib/test/mapping_tests.py
@@ -88,7 +88,6 @@ class BasicTestMappingProtocol(unittest.TestCase):
         self.assertEqual(d.get(knownkey, knownvalue), knownvalue)
         self.assertNotIn(knownkey, d)
 
-    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_write(self):
         # Test for write operations on mapping
         p = self._empty_mapping()
@@ -171,7 +170,6 @@ class BasicTestMappingProtocol(unittest.TestCase):
 
         self.assertRaises(TypeError, d.__getitem__)
 
-    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_update(self):
         # mapping argument
         d = self._empty_mapping()
@@ -293,7 +291,6 @@ class BasicTestMappingProtocol(unittest.TestCase):
         self.assertRaises(KeyError, d.popitem)
         self.assertRaises(TypeError, d.popitem, 42)
 
-    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_pop(self):
         d = self._empty_mapping()
         k, v = list(self.inmapping.items())[0]

--- a/www/src/Lib/test/test_grammar.py
+++ b/www/src/Lib/test/test_grammar.py
@@ -10,10 +10,10 @@ from sys import *
 
 # different import patterns to check that __annotations__ does not interfere
 # with import machinery
-import test.ann_module as ann_module
+# import test.ann_module as ann_module  # Doesn't work in Brython
 import typing
 from collections import ChainMap
-from test import ann_module2
+# from test import ann_module2  # Doesn't work in Brython
 import test
 
 # These are shared with test_tokenize and other test modules.
@@ -110,6 +110,7 @@ class TokenTests(unittest.TestCase):
         x = 0
         self.assertEqual(x, 0, 'backslash ending comment')
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_plain_integers(self):
         self.assertEqual(type(000), type(0))
         self.assertEqual(0xff, 255)
@@ -170,12 +171,14 @@ class TokenTests(unittest.TestCase):
         x = .3e14
         x = 3.1e4
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_float_exponent_tokenization(self):
         # See issue 21642.
         self.assertEqual(1 if 1else 0, 1)
         self.assertEqual(1 if 0else 0, 0)
         self.assertRaises(SyntaxError, eval, "0 if 1Else 0")
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_underscore_literals(self):
         for lit in VALID_UNDERSCORE_LITERALS:
             self.assertEqual(eval(lit), eval(lit.replace('_', '')))
@@ -224,11 +227,13 @@ the \'lazy\' dog.\n\
 '
         self.assertEqual(x, y)
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_ellipsis(self):
         x = ...
         self.assertTrue(x is Ellipsis)
         self.assertRaises(SyntaxError, eval, ".. .")
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_eof_error(self):
         samples = ("def foo(", "\ndef foo(", "def foo(\n")
         for s in samples:
@@ -264,6 +269,7 @@ class GrammarTests(unittest.TestCase):
         # testlist ENDMARKER
         x = eval('1, 0 or 1')
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_basics(self):
         # all these should be allowed
         var1: int = 5
@@ -276,6 +282,7 @@ class GrammarTests(unittest.TestCase):
         my_lst[one()-1]: int = 5
         self.assertEqual(my_lst, [5])
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_syntax_errors(self):
         # parser pass
         check_syntax_error(self, "def f: int")
@@ -296,6 +303,7 @@ class GrammarTests(unittest.TestCase):
                                  "    global x\n"
                                  "    x: int\n")
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_basic_semantics(self):
         # execution order
         with self.assertRaises(ZeroDivisionError):
@@ -342,6 +350,7 @@ class GrammarTests(unittest.TestCase):
                 x: int
                 x.y: list = []
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_metaclass_semantics(self):
         class CMeta(type):
             @classmethod
@@ -351,6 +360,7 @@ class GrammarTests(unittest.TestCase):
             XX: 'ANNOT'
         self.assertEqual(CC.__annotations__['xx'], 'ANNOT')
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_module_semantics(self):
         with self.assertRaises(AttributeError):
             print(test.__annotations__)
@@ -360,6 +370,7 @@ class GrammarTests(unittest.TestCase):
                               {'123': 123, 'o': type})
         self.assertEqual(ann_module2.__annotations__, {})
 
+    @unittest.skip('Fails in Brython')
     def test_var_annot_in_module(self):
         # check that functions fail the same way when executed
         # outside of module where they were defined
@@ -380,6 +391,7 @@ class GrammarTests(unittest.TestCase):
         with self.assertRaises(KeyError):
             gns['__annotations__']
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_custom_maps(self):
         # tests with custom locals() and __annotations__
         ns = {'__annotations__': CNS()}
@@ -401,6 +413,7 @@ class GrammarTests(unittest.TestCase):
         exec('x: int = 1', {}, CNS2())
         self.assertEqual(nonloc_ns['__annotations__']['x'], int)
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_var_annot_refleak(self):
         # complex case: custom locals plus custom __annotations__
         # this was causing refleak
@@ -418,6 +431,7 @@ class GrammarTests(unittest.TestCase):
         exec('X: str', {}, CNS2())
         self.assertEqual(nonloc_ns['__annotations__']['x'], str)
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_funcdef(self):
         ### [decorators] 'def' NAME parameters ['->' test] ':' suite
         ### decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
@@ -637,6 +651,7 @@ class GrammarTests(unittest.TestCase):
         def f(a, *args, b, **kwds,): pass
         def f(a, *, b, **kwds,): pass
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_lambdef(self):
         ### lambdef: 'lambda' [varargslist] ':' test
         l1 = lambda : 0
@@ -687,6 +702,7 @@ class GrammarTests(unittest.TestCase):
     ### small_stmt: expr_stmt | pass_stmt | del_stmt | flow_stmt | import_stmt | global_stmt | access_stmt
     # Tested below
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_expr_stmt(self):
         # (exprlist '=')* exprlist
         1
@@ -702,6 +718,7 @@ class GrammarTests(unittest.TestCase):
 
     # Check the heuristic for print & exec covers significant cases
     # As well as placing some limits on false positives
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_former_statements_refer_to_builtins(self):
         keywords = "print", "exec"
         # Cases where we want the custom error
@@ -797,6 +814,7 @@ class GrammarTests(unittest.TestCase):
                 self.fail("continue then break in try/except in loop broken!")
         test_inner()
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_return(self):
         # 'return' [testlist]
         def g1(): return
@@ -879,6 +897,7 @@ class GrammarTests(unittest.TestCase):
                 return 4
         self.assertEqual(g3(), 4)
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_yield(self):
         # Allowed as standalone statement
         def g(): yield 1
@@ -915,6 +934,7 @@ class GrammarTests(unittest.TestCase):
         # Check annotation refleak on SyntaxError
         check_syntax_error(self, "def g(a:(yield)): pass")
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_yield_in_comprehensions(self):
         # Check yield in comprehensions
         def g(): [x for x in [(yield 1)]]
@@ -1003,7 +1023,7 @@ class GrammarTests(unittest.TestCase):
                       "raised an AssertionError")
 
     # these tests fail if python is run with -O, so check __debug__
-    @unittest.skipUnless(__debug__, "Won't work if __debug__ is False")
+    @unittest.skip("Only meant for CPython")
     def testAssert2(self):
         try:
             assert 0, "msg"
@@ -1051,6 +1071,7 @@ class GrammarTests(unittest.TestCase):
             x = 2
         self.assertEqual(x, 2)
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_for(self):
         # 'for' exprlist 'in' exprlist ':' suite ['else' ':' suite]
         for i in 1, 2, 3: pass
@@ -1172,6 +1193,7 @@ class GrammarTests(unittest.TestCase):
         x = ~1 ^ 1 & 1 | 1 & 1 ^ -1
         x = -1*1/1 + 1*1 - ---1*1
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_selectors(self):
         ### trailer: '(' [testlist] ')' | '[' subscript ']' | '.' NAME
         ### subscript: expr | [expr] ':' [expr]
@@ -1263,6 +1285,7 @@ class GrammarTests(unittest.TestCase):
         nums = [1, 2, 3]
         self.assertEqual({i:i+1 for i in nums}, {1: 2, 2: 3, 3: 4})
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_listcomps(self):
         # list comprehension tests
         nums = [1, 2, 3, 4, 5]
@@ -1326,6 +1349,7 @@ class GrammarTests(unittest.TestCase):
         self.assertEqual(x, [('Boeing', 'Airliner'), ('Boeing', 'Engine'), ('Ford', 'Engine'),
                              ('Macdonalds', 'Cheeseburger')])
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_genexps(self):
         # generator expression tests
         g = ([x for x in range(10)] for x in range(1))
@@ -1361,6 +1385,7 @@ class GrammarTests(unittest.TestCase):
         check_syntax_error(self, "foo(x for x in range(10), 100)")
         check_syntax_error(self, "foo(100, x for x in range(10))")
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_comprehension_specials(self):
         # test for outmost iterable precomputation
         x = 10; g = (i for i in range(x)); x = 5
@@ -1400,6 +1425,7 @@ class GrammarTests(unittest.TestCase):
         with manager() as x, manager():
             pass
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_if_else_expr(self):
         # Test ifelse expressions in various cases
         def _checkeval(msg, ret):
@@ -1470,6 +1496,7 @@ class GrammarTests(unittest.TestCase):
         self.assertEqual(test2.__name__, 'test2')
         self.assertTrue(bool(test2.__code__.co_flags & inspect.CO_COROUTINE))
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_async_for(self):
         class Done(Exception): pass
 
@@ -1493,6 +1520,7 @@ class GrammarTests(unittest.TestCase):
         with self.assertRaises(Done):
             foo().send(None)
 
+    @unittest.skip('Fails in Brython -- still needs to be investigated')
     def test_async_with(self):
         class Done(Exception): pass
 

--- a/www/tests/qunit/run_tests.html
+++ b/www/tests/qunit/run_tests.html
@@ -156,7 +156,9 @@ qunit_add_tests(test_utils.load_brython_test_cases('..'))
 
 from unittest.loader import TestLoader
 import test.test_dict
+import test.test_grammar
 qunit_add_tests(TestLoader().loadTestsFromModule(test.test_dict))
+qunit_add_tests(TestLoader().loadTestsFromModule(test.test_grammar))
 
 </script>
 


### PR DESCRIPTION
Thanks to your fixes in #1024, CPython's test_grammar.py file can now be compiled and run in Brython. There are a few tests that fail, so I mark them as skipped so that the CI build will still pass. In case you don't have enough things on your todo list, now you can work through these :)

I removed the `@unittest.skip`'s from the dict tests that you already got working.