### PR TITLE
Fix: `javascript.JSON.parse` crash parsing object containing null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ setup/data/*.js
 
 # Files created by make_doc
 www/static_doc
+
+# Jetbrains IDEs
+*.iml
+.idea

--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -39,7 +39,9 @@ $B.pyobj2structuredclone = function(obj){
     }
 }
 $B.structuredclone2pyobj = function(obj){
-    if(typeof obj == "boolean" || typeof obj == "number" ||
+    if(obj === null){
+        return _b_.None
+    }else if(typeof obj == "boolean" || typeof obj == "number" ||
             typeof obj == "string"){
         return obj
     }else if(obj instanceof Number){

--- a/www/tests/test_jsobjects.py
+++ b/www/tests/test_jsobjects.py
@@ -71,3 +71,8 @@ except TypeError:
 x = window.initJSWithEq()
 assert 'x' == x
 assert x == 'x'
+
+# test parsing json with a null value
+import javascript
+obj = javascript.JSON.parse('{"foo": null}')
+assert obj == {"foo": None}


### PR DESCRIPTION
Using `javascript.JSON.parse` produced an error, that `null` does not contain attribute `__class__`.

