### PR TITLE
easily share code

### DIFF
--- a/www/tests/editor.html
+++ b/www/tests/editor.html
@@ -82,6 +82,7 @@ doc['set_debug'].bind('change',set_debug)
 
 # next functions are defined in editor.py
 doc['show_js'].bind('click',editor.show_js)
+doc['share_code'].bind('click',editor.share_code)
 # Create a lambda around editor.run() so that the event object is not passed to it
 doc['run'].bind('click',lambda *args: editor.run())
 doc['show_console'].bind('click',editor.show_console)
@@ -123,6 +124,7 @@ function run_js(){
         Debug<input type="checkbox" id="set_debug" checked>
         <button id="show_console">Python</button>
         <button id="show_js">Javascript</button>
+		<button id="share_code">Share code</button>
     </td>
   </tr>
 

--- a/www/tests/editor.py
+++ b/www/tests/editor.py
@@ -41,10 +41,14 @@ if 'set_debug' in doc:
     __BRYTHON__.debug = int(doc['set_debug'].checked)
 
 def reset_src():
-    if storage is not None and "py_src" in storage:
-        editor.setValue(storage["py_src"])
+    if "code" in window.location.href:
+        code = window.location.href.split("&code=")[1].split("&")[0]
+        editor.setValue(window.decodeURIComponent(code))
     else:
-        editor.setValue('for i in range(10):\n\tprint(i)')
+        if storage is not None and "py_src" in storage:
+            editor.setValue(storage["py_src"])
+        else:
+            editor.setValue('for i in range(10):\n\tprint(i)')
     editor.scrollToRow(0)
     editor.gotoLine(0)
 
@@ -123,6 +127,12 @@ def run(*args):
 def show_js(ev):
     src = editor.getValue()
     doc["console"].value = javascript.py2js(src, '__main__')
+
+def share_code(ev):
+    src = editor.getValue()
+    src = window.encodeURIComponent(src)
+    url = f"https://brython.info/tests/editor.html?lang=en&code={src}"
+    alert(f"Copy the url: {url}")
 
 if has_ace:
     reset_src()


### PR DESCRIPTION
The PR adds some functionality to the editor that allows a user to share the code snippet with others just using a URL.

There is a new button called `share_code` where you can get a url. The code from the editor is included in the url so when you paste this url in the browser the editor will show the same code you are using.

Please, let me know if it is useful.