### PR TITLE
fix problem with parenthesis in url encoding

### DIFF
--- a/www/tests/editor.html
+++ b/www/tests/editor.html
@@ -50,7 +50,7 @@ from browser import document as doc, window
 from browser import html
 import header
 
-import editor_kiko as editor
+import editor
 
 qs_lang,language = header.show()
 

--- a/www/tests/editor.py
+++ b/www/tests/editor.py
@@ -133,7 +133,6 @@ def show_js(ev):
 
 def share_code(ev):
     src = editor.getValue()
-    #src = window.encodeURIComponent(src)
     if len(src) > 2048:
         d = dialog.InfoDialog("Copy url",
                               f"code length is {len(src)}, must be < 2048",
@@ -144,6 +143,7 @@ def share_code(ev):
         query = doc.query
         query["code"] = src
         url = f"{href}{query}"
+        url = url.replace("(", "%28").replace(")", "%29")
         d = dialog.Dialog("Copy url", style={"zIndex": 10})
         area = html.TEXTAREA(rows=0, cols=0)
         d.panel <= area


### PR DESCRIPTION
There is a problem when you share a URl with parenthesis. In some contexts the URL will not work. It is necessary to encode the parenthesis signs.