### PR TITLE
Added entrypoint 'console_scripts' to setup.py

### DIFF
--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -10,6 +10,7 @@ import argparse
 from . import implementation
 
 
+
 def main():
     parser = argparse.ArgumentParser()
 

--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -9,8 +9,8 @@ import argparse
 
 from . import implementation
 
-if __name__ == "__main__":
 
+def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--add_package',
@@ -38,7 +38,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    print(args.make_file_system)
     files = ['README.txt', 'demo.html', 'index.html',
         'brython.js', 'brython_stdlib.js', 'unicode.txt']
 
@@ -137,3 +136,6 @@ if __name__ == "__main__":
         from . import make_package
         make_package.make(package_name, os.getcwd())
         print("done")
+
+if __name__ == "__main__":
+    main()

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -153,7 +153,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'brython = brython.__main__:main'
+            'brython-cli = brython.__main__:main'
             ]
     }
 

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -150,6 +150,12 @@ setup(
 
     package_data={
         'brython': ['data/*.*']
+    },
+    entry_points={
+        'console_script': [
+            'brython = brython.__main__:main'
+            ]
     }
+
 
 )

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -152,7 +152,7 @@ setup(
         'brython': ['data/*.*']
     },
     entry_points={
-        'console_script': [
+        'console_scripts': [
             'brython = brython.__main__:main'
             ]
     }


### PR DESCRIPTION
When installing brython via pip of setup.py this will now add a script `brython` to the path that acts the same as `python -m brython`.