### PR TITLE
Improved perfomance of builtin objects, initial changes that is done for discussion

### DIFF
--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -434,37 +434,15 @@ $B.make_rmethods(list)
 var _ops = ["add", "sub"]
 
 list.append = function(){
-    try {
-        var self = arguments[0];
-        for (var i = 1; i < arguments.length; ++i) {
-            self[self.length] = arguments[i];
-        }
-    } catch (err) {
-        // NOTE(redradist): Seems like performance is low
-        // due to parsing complex arguments everytime
-        // Lets call arguments directly without $B.args for simple cases
-        // for all other cases leave it as it is
-        var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
-            arguments, {}, null, null)
-        $.self[$.self.length] = $.x
-    }
+    // NOTE(redradist): Seems like performance is low
+    // due to parsing complex arguments each time
+    // Lets call arguments directly without $B.args for simple cases
+    // for all other cases leave it as it is
 
-    // var posArgs = $B.posArgs(arguments);
-    // if (posArgs === arguments.length-1) {
-    //     var self = arguments[0];
-    //     for (var i = 1; i < posArgs.length; ++i) {
-    //         var x = posArgs[i];
-    //         self[self.length] = x
-    //     }
-    // } else {
-    //     // NOTE(redradist): Seems like performance is low
-    //     // due to parsing complex arguments everytime
-    //     // Lets call arguments directly without $B.args for simple cases
-    //     // for all other cases leave it as it is
-    //     var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
-    //         arguments, {}, null, null)
-    //     $.self[$.self.length] = $.x
-    // }
+    // Simple positional argument
+    var self = arguments[0];
+    var x = arguments[1];
+    self[self.length] = x;
     return $N
 }
 

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -434,11 +434,22 @@ $B.make_rmethods(list)
 var _ops = ["add", "sub"]
 
 list.append = function(){
-    var self = arguments[0];
-    var x = arguments[1];
-    self[self.length] = x
+    try {
+        var self = arguments[0];
+        for (var i = 1; i < arguments.length; ++i) {
+            self[self.length] = arguments[i];
+        }
+    } catch (err) {
+        // NOTE(redradist): Seems like performance is low
+        // due to parsing complex arguments everytime
+        // Lets call arguments directly without $B.args for simple cases
+        // for all other cases leave it as it is
+        var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
+            arguments, {}, null, null)
+        $.self[$.self.length] = $.x
+    }
 
-    // var posArgs = $B.applyPosArgs(arguments);
+    // var posArgs = $B.posArgs(arguments);
     // if (posArgs === arguments.length-1) {
     //     var self = arguments[0];
     //     for (var i = 1; i < posArgs.length; ++i) {

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -438,13 +438,22 @@ list.append = function(){
     var x = arguments[1];
     self[self.length] = x
 
-    // NOTE(redradist): Seems like performance is low
-    // due to parsing complex arguments everytime
-    // Lets call arguments directly without $B.args for simple cases
-    // for all other cases leave it as it is
-    // var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
-    //     arguments, {}, null, null)
-    // $.self[$.self.length] = $.x
+    // var posArgs = $B.applyPosArgs(arguments);
+    // if (posArgs === arguments.length-1) {
+    //     var self = arguments[0];
+    //     for (var i = 1; i < posArgs.length; ++i) {
+    //         var x = posArgs[i];
+    //         self[self.length] = x
+    //     }
+    // } else {
+    //     // NOTE(redradist): Seems like performance is low
+    //     // due to parsing complex arguments everytime
+    //     // Lets call arguments directly without $B.args for simple cases
+    //     // for all other cases leave it as it is
+    //     var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
+    //         arguments, {}, null, null)
+    //     $.self[$.self.length] = $.x
+    // }
     return $N
 }
 

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -22,6 +22,7 @@ function $list(){
 
 var list = {
     __class__: _b_.type,
+    __proto__: Array.prototype,
     __mro__: [object],
     $infos: {
         __module__: "builtins",
@@ -434,9 +435,16 @@ $B.make_rmethods(list)
 var _ops = ["add", "sub"]
 
 list.append = function(){
-    var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
-        arguments, {}, null, null)
-    $.self[$.self.length] = $.x
+    var self = arguments[0];
+    var value = arguments[1];
+    self.push(value);
+    // NOTE(redradist): Instead of accessing Python object,
+    // lets use optimized JavaScript Array for cases
+    // where mapping could be done
+    // var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
+    //     arguments, {}, null, null)
+    // $.self[$.self.length] = $.x
+
     return $N
 }
 

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -22,7 +22,6 @@ function $list(){
 
 var list = {
     __class__: _b_.type,
-    __proto__: Array.prototype,
     __mro__: [object],
     $infos: {
         __module__: "builtins",
@@ -436,15 +435,16 @@ var _ops = ["add", "sub"]
 
 list.append = function(){
     var self = arguments[0];
-    var value = arguments[1];
-    self.push(value);
-    // NOTE(redradist): Instead of accessing Python object,
-    // lets use optimized JavaScript Array for cases
-    // where mapping could be done
+    var x = arguments[1];
+    self[self.length] = x
+
+    // NOTE(redradist): Seems like performance is low
+    // due to parsing complex arguments everytime
+    // Lets call arguments directly without $B.args for simple cases
+    // for all other cases leave it as it is
     // var $ = $B.args("append", 2 ,{self: null, x: null}, ["self", "x"],
     //     arguments, {}, null, null)
     // $.self[$.self.length] = $.x
-
     return $N
 }
 

--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -6,6 +6,17 @@ var _b_ = $B.builtins,
             ("function" === typeof importScripts) &&
             (navigator instanceof WorkerNavigator)
 
+$B.applyPosArgs = function(args) {
+    var pos_args = [];
+    try {
+        var self = args[0];
+        for (var i = 1; i < args.length; ++i) {
+            pos_args.push(args[i]);
+        }
+    } catch (err) {}
+    return pos_args;
+}
+
 $B.args = function($fname, argcount, slots, var_names, args, $dobj,
     extra_pos_args, extra_kw_args){
     // builds a namespace from the arguments provided in $args

--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -6,7 +6,7 @@ var _b_ = $B.builtins,
             ("function" === typeof importScripts) &&
             (navigator instanceof WorkerNavigator)
 
-$B.applyPosArgs = function(args) {
+$B.posArgs = function(args) {
     var pos_args = [];
     try {
         var self = args[0];


### PR DESCRIPTION
As was discussed in this issue:

https://github.com/brython-dev/brython/issues/1419

`Brython` is less efficinet than JavaScript ...
It is due to Object.$B.getattrib called more times

Native types like Array in V8 is optimized

`Python` list object is not inherited from other object that mean we could optimize default behavior of object with getting attribute and instead append and remove from native `JavaScript Array` object

Before optimization:
```console
javascript: 2.59716796875ms
brython.js:5316 using indexedDB for stdlib modules cache
brython.js:9073 python: 289.85302734375ms
```

After optimization:
```console
javascript: 2.6259765625ms
brython.js:5243 using indexedDB for stdlib modules cache
brython.js:9031 python: 51.942138671875ms
```

I would like to discuss this optimization after initial commit ... to not uselessly spent my time )