### PR TITLE
update bokeh lib to take into account changes in the API

### DIFF
--- a/www/gallery/bokeh.html
+++ b/www/gallery/bokeh.html
@@ -2,7 +2,8 @@
 <head>
     <title>Getting Started with bokeh - Brython version</title>
     <meta charset="iso-8859-1">
-    <script type="text/javascript" src="https://cdn.pydata.org/bokeh/release/bokeh-0.12.0.min.js"></script>
+	<script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-2.1.1.min.js"></script>
+	<script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-api-2.1.1.min.js"></script>
     <style>
     body{
         font-family: sans-serif;


### PR DESCRIPTION
Updating the bokeh.html page to use the latest versions of the libraries, bokeh-2.1.1.min.js and bokeh-api-2.1.1.min.js