### PR TITLE
_sre.scanner takes keyword arguments pos, endpos in recent Python

### DIFF
--- a/www/src/Lib/_sre.py
+++ b/www/src/Lib/_sre.py
@@ -215,7 +215,7 @@ class SRE_Pattern:
         #return iter(scanner.search, None)
 
     def scanner(self, string, pos=0, endpos=sys.maxsize):
-        return SRE_Scanner(self, string, start, end)
+        return SRE_Scanner(self, string, pos, endpos)
 
     def __copy__(self):
         raise TypeError("cannot copy this pattern object")

--- a/www/src/Lib/_sre.py
+++ b/www/src/Lib/_sre.py
@@ -214,7 +214,7 @@ class SRE_Pattern:
         return _list
         #return iter(scanner.search, None)
 
-    def scanner(self, string, start=0, end=sys.maxsize):
+    def scanner(self, string, pos=0, endpos=sys.maxsize):
         return SRE_Scanner(self, string, start, end)
 
     def __copy__(self):


### PR DESCRIPTION
https://github.com/python/cpython/blob/v3.8.5/Lib/test/test_re.py#L1885-L1887

I didn't try to fix but `SRE_Match.__init__` seems unnessessarilly set `lastindex` as `None` for negative. If there is no other bug, the only possible nagative value is `-1` and it will allow the original code run without problem.