### PR TITLE
more robust detection of current line

### DIFF
--- a/www/src/Lib/interpreter.py
+++ b/www/src/Lib/interpreter.py
@@ -196,12 +196,12 @@ class Interpreter:
                 return
             src = self.zone.value
             if self._status == "main":
-                currentLine = src[src.rfind('>>>') + 4:]
+                currentLine = src[src.rfind('\n>>>') + 5:]
             elif self._status == "3string":
-                currentLine = src[src.rfind('>>>') + 4:]
+                currentLine = src[src.rfind('\n>>>') + 5:]
                 currentLine = currentLine.replace('\n... ', '\n')
             else:
-                currentLine = src[src.rfind('...') + 4:]
+                currentLine = src[src.rfind('\n...') + 5:]
             if self._status == 'main' and not currentLine.strip():
                 self.zone.value += '\n>>> '
                 event.preventDefault()


### PR DESCRIPTION
Avoids the following bug (can be reproduced in https://brython.info/tests/console.html) :

```
Brython 3.9.1 on Netscape 5.0 (X11)
>>> print("test"); print("lipsum")
test
lipsum
>>> print("test"); print(">>>"); print("lipsum")
  File <string>, line 1
    ); print("lipsum")
    ^
SyntaxError: invalid syntax (Unexpected closing bracket)
>>> 
```

Note that even with this modification there may be some cases where the computation of `currentLine` fails.