### PR TITLE
Show module path when it cannot be read

### DIFF
--- a/setup/brython/list_modules.py
+++ b/setup/brython/list_modules.py
@@ -15,6 +15,9 @@ import time
 import io
 import tokenize
 import token
+import logging
+
+logger = logging.getLoger(__name__)
 
 # Template for application setup.py script
 setup = """from setuptools import setup, find_packages
@@ -565,7 +568,10 @@ def load_user_modules(module_dir=os.getcwd()):
                 # modules in the same directory
                 path = os.path.join(dirname, filename)
                 with open(path, encoding="utf-8") as fobj:
-                    src = fobj.read()
+                    try:
+                        src = fobj.read()
+                    except:
+                        logger.error("Unable to read %s", path)
                 mf = ModulesFinder(dirname)
                 imports = sorted(list(mf.get_imports(src)))
                 user_modules[name] = [ext, src, imports]


### PR DESCRIPTION
My existing project contains lots of python files, some of them were historically encoded by non-UTF8. Those files would fail the `brython-cli --modules`. This change will output the offending files, so that I can know which file to be fixed.