### PR TITLE
Fix parentheses in lambda tests

### DIFF
--- a/www/tests/test_suite.py
+++ b/www/tests/test_suite.py
@@ -687,9 +687,9 @@ assert (lambda: (
     '''
 ))() == "\n    # not a comment\n    hi\n    "
 
-assert lambda:(  # A greeter.
-    print('hi')  # Short for "Hello".
-)() == 'hi'
+assert (lambda: (  # A greeter.
+    'hi'           # Short for "Hello".
+))() == 'hi'
 
 # issue 1557
 assertRaises(SyntaxError, exec, "a, b += 1")


### PR DESCRIPTION
The updated tests still fail as expected in commit 82dd990, so they should prevent regressions of issue #1545. And now they don't seem to be asserting that `print('hi') == 'hi'` at first glance :)