### PR TITLE
Fix bugs in string partition

### DIFF
--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -1814,8 +1814,8 @@ str.partition = function() {
         throw _b_.ValueError.$factory("empty separator")
     }
     check_str($.sep)
-    var chars = to_chars(self),
-        i = chars.indexOf($.sep)
+    var chars = to_chars($.self),
+        i = $.self.indexOf($.sep)
     if(i == -1){
         return _b_.tuple.$factory([$.self, "", ""])
     }

--- a/www/tests/test_strings.py
+++ b/www/tests/test_strings.py
@@ -404,5 +404,50 @@ try:
 except AttributeError as exc:
     assert exc.args[0] == "'str' object has no attribute '__dict__'"
 
+# tests for partition
+assert ''.partition('.') == ('', '', '')
+assert 'a'.partition('.') == ('a', '', '')
+assert '.'.partition('.') == ('', '.', '')
+assert 'a.'.partition('.') == ('a', '.', '')
+assert 'a.b'.partition('.') == ('a', '.', 'b')
+assert 'a.b.c'.partition('.') == ('a', '.', 'b.c')
+assert 'a__b'.partition('__') == ('a', '__', 'b')
+assert 'a'.partition('__') == ('a', '', '')
+assert 'a__b__c'.partition('__') == ('a', '__', 'b__c')
+
+try:
+    ''.partition('')
+    raise AssertionError('should have raised ValueError')
+except ValueError as exc:
+    assert exc.args[0] == 'empty separator'
+
+try:
+    ''.partition(5)
+    raise AssertionError('should have raised TypeError')
+except TypeError as exc:
+    assert exc.args[0] == "can't convert 'int' object to str implicitly"
+
+# tests for rpartition
+assert ''.rpartition('.') == ('', '', '')
+assert 'a'.rpartition('.') == ('', '', 'a')
+assert '.'.rpartition('.') == ('', '.', '')
+assert 'a.'.rpartition('.') == ('a', '.', '')
+assert 'a.b'.rpartition('.') == ('a', '.', 'b')
+assert 'a.b.c'.rpartition('.') == ('a.b', '.', 'c')
+assert 'a__b'.rpartition('__') == ('a', '__', 'b')
+assert 'a'.rpartition('__') == ('', '', 'a')
+assert 'a__b__c'.rpartition('__') == ('a__b', '__', 'c')
+
+try:
+    ''.rpartition('')
+    raise AssertionError('should have raised ValueError')
+except ValueError as exc:
+    assert exc.args[0] == 'empty separator'
+
+try:
+    ''.rpartition(5)
+    raise AssertionError('should have raised TypeError')
+except TypeError as exc:
+    assert exc.args[0] == "can't convert 'int' object to str implicitly"
 
 print("passed all tests...")


### PR DESCRIPTION
`to_chars(self)` rather than `to_chars($.self)` was causing the pickle tests to fail, and while writing the partition tests I noticed that partitions greater than 1 character long were breaking as well