### PR TITLE
Fix formatting of lambda in traceback tests

### DIFF
--- a/www/tests/qunit/run_tests.html
+++ b/www/tests/qunit/run_tests.html
@@ -113,7 +113,7 @@ def testTraceback(qunit):
         trace = traceback.format_exc()
         assert "line 9, in f" in trace
         assert "line 6, in h" in trace
-        assert "line 5, in lambda" in trace
+        assert "line 5, in <lambda>" in trace
         assert "line 2, in g" in trace
 
     # issue 976


### PR DESCRIPTION
The fix for #1645 modified the traceback slightly. This PR updates the tests to match