### PR TITLE
Accept Interpreter History as Argument

### DIFF
--- a/www/src/Lib/interpreter.py
+++ b/www/src/Lib/interpreter.py
@@ -105,7 +105,7 @@ class Interpreter:
     """Add a Python interactive interpreter in a textarea."""
 
     def __init__(self, elt_id=None, title="Interactive Interpreter",
-                 globals=None, locals=None,
+                 globals=None, locals=None, history=None,
                  rows=30, cols=84, default_css=True,
                  clear_zone=True, banner=True):
         """
@@ -113,6 +113,7 @@ class Interpreter:
         - "elt_id" is the id of a textarea in the document. If not set, a new
           popup window is added with a textarea.
         - "globals" and "locals" are the namespaces the RPEL runs in
+        - "history", if set, must be a list of strings
         """
         if default_css:
             # Insert default CSS stylesheet if not already loaded
@@ -159,8 +160,8 @@ class Interpreter:
         self.zone.value += ">>> "
         self.cursor_to_end()
         self._status = "main"
-        self.current = 0
-        self.history = []
+        self.history = history or []
+        self.current = len(self.history)
 
         self.globals = {} if globals is None else globals
         self.globals.update(editor_ns)


### PR DESCRIPTION
Allows restoring history from a previous interpreter instance.

**Things I am no sure about:**
- we could *copy* the object (`self.history = [*history]`?) to make it safer to use internally, but I am not sure of the consequences given it's JavaScript underneath. Not sure it's worth it.

I did *not* run the test suite, but given how small the change is... I did test it in my own project that uses Brython, though.