### PR TITLE
added test of readline/readlines - issue #1763

### DIFF
--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -3002,6 +3002,40 @@ assertRaises(SyntaxError, exec,
     if True:
         f() += 1''')
 
+
+# issue #1763
+# problem with readlines working wrong on linux text files.
+import io
+
+def myreadlines(self):
+    """Read and return the list of all logical lines using readline."""
+    lines = []
+    while True:
+        line = self.readline()
+        if not line:
+            return lines
+        else:
+            lines.append(line)
+
+# test readline
+assert len(myreadlines(io.StringIO("foo\n\n\n"))) == 3, r"myreadline failed with \n\n"
+assert (
+    len(myreadlines(io.StringIO("foo\r\n\r\n\r\n"))) == 3
+), r"myreadline failed with \r\n\r\n"
+
+# Test readlines()
+assert (
+    len(io.StringIO("foo\r\n\r\n\r\n").readlines()) == 3
+), r"readlines failed with \r\n"
+
+with open("compression/du cote de chez swann.txt", "rb") as f:
+    assert len(f.readlines()) == 2118, "readlines (binary mode) failed on file"
+
+assert len(io.StringIO("foo\n\n\n").readlines()) == 3, r"readlines failed with \n\n!"
+
+with open("compression/du cote de chez swann.txt", "r") as f:
+    assert len(f.readlines()) == 2118, "readlines (text mode) failed on file"
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
With opened files, readline() seems to be working ok
but  readlines() is having some problem with linux
text files; binary mode works fine.

When readlines() is used,
files ending by '\n\n' are not having correct number of lines.

This merge request contains **only tests, not solution**.
I am not sure if merging this without solution is worth it, 
but at least it is here to remind you something needs a fix.
