### PR TITLE
Correct charCode conversion in docs

### DIFF
--- a/www/doc/en/keyboard_events.md
+++ b/www/doc/en/keyboard_events.md
@@ -77,7 +77,7 @@ document["altKey"].bind("keypress", keypress)
 #### Example
 
 Enter text in the entry below. Note that the character can be read by
-`ch(ev.charCode)`
+`chr(ev.charCode)`
 
 <input id="charCode" value="" autocomplete="off">&nbsp;
 <span id="traceCharCode">&nbsp;</span>
@@ -147,7 +147,7 @@ some keyboard shortcuts using the Ctrl key.
 #### Example
 
 Enter text in the entry fields below. Note that the character can be read by
-`ch(ev.charCode)` with the *keypress* event
+`chr(ev.charCode)` with the *keypress* event
 
 with *keydown* <input id="keyCodeKeydown" value="" autocomplete="off">
 

--- a/www/doc/es/keyboard_events.md
+++ b/www/doc/es/keyboard_events.md
@@ -77,7 +77,7 @@ document["altKey"].bind("keypress", keypress)
 #### Ejemplo
 
 Introduce texto en el campo de más abajo. Date cuenta que el carácter se puede 
-leer mediante `ch(ev.charCode)`
+leer mediante `chr(ev.charCode)`
 
 <input id="charCode" value="" autocomplete="off">&nbsp;
 <span id="traceCharCode">&nbsp;</span>
@@ -147,7 +147,7 @@ algunos atajos de teclado que usan la tecla Ctrl
 #### Ejemplo
 
 Introduce texto en el campo de más abajo. Date cuenta que el carácter se puede 
-leer mediante `ch(ev.charCode)` con el evento *keypress*
+leer mediante `chr(ev.charCode)` con el evento *keypress*
 
 con *keydown* <input id="keyCodeKeydown" value="" autocomplete="off">
 
@@ -218,7 +218,7 @@ document["shiftKey"].bind("keypress", keypress)
 #### Ejemplo
 
 Introduce texto en el campo de más abajo. Date cuenta que el carácter se puede 
-leer mediante `ch(ev.which)` del evento *keypress*
+leer mediante `chr(ev.which)` del evento *keypress*
 
 
 <table>

--- a/www/doc/fr/keyboard_events.md
+++ b/www/doc/fr/keyboard_events.md
@@ -147,7 +147,7 @@ défaut associé à certains raccourcis clavier qui utilisent la touche Ctrl.
 #### Example
 
 Saisissez du texte dans les champs de saisie ci-dessous. Notez que le
-caractère peut être lu par `ch(ev.charCode)` avec l'événement *keypress*
+caractère peut être lu par `chr(ev.charCode)` avec l'événement *keypress*
 
 avec *keydown* <input id="keyCodeKeydown" autocomplete="off">
 


### PR DESCRIPTION
The docs state you should use `ch(ev.charCode)`, but the correct function is `chr`.
Corrected for en, fr, es.