### PR TITLE
Remove extra space before viewport meta

### DIFF
--- a/www/benchmarks/index.html
+++ b/www/benchmarks/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <script type="text/javascript" src="../../src/brython.js"></script>
 
   <script type="text/python">


### PR DESCRIPTION
This file has an extra space before the first meta tag.