### PR TITLE
fix str.startswith() with start argument

### DIFF
--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -2298,7 +2298,7 @@ str.startswith = function(){
     if(! _b_.isinstance(prefixes, _b_.tuple)){
         prefixes = [prefixes]
     }
-    var s = $.self.substring($.js_start, $.js_end)
+    var s = $.self.substring($.start, $.end)
     for(var prefix of prefixes){
         if(! _b_.isinstance(prefix, str)){
             throw _b_.TypeError.$factory("endswith first arg must be str " +


### PR DESCRIPTION
Thanks for this great project!

I had an issue using *brython*, where the following test page would not work:
```html
<!doctype html>
<html>

<head>
<meta charset="utf-8">
<script type="text/javascript" src="brython.js"></script>
<script type="text/javascript" src="brython_stdlib.js"></script>
</head>

<body onload="brython(1)">
<script type="text/python">
from browser import document

if "abc".startswith("b", 1):
  document <= "Yes, startswith() condition is TRUE"
else:
  document <= "No"
</script>
</body>

</html>
```

The text "No" would display in my browser, whereas I expected the 'startswith()' function to compare "b" to the string starting at position 1, "bc".

Patching the corresponding code in the fashion proposed here fixed the problem. (I directly patched the compiled `brython.js`, with the edit location found by searching for the definition of `str.startswith`. I'm assuming that the `brython.js` is compiled by putting together these js sources.)

```
> brython-cli --version
Brython version 3.10.4
```