### PR TITLE
Rewrite cli interface

### DIFF
--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -4,40 +4,88 @@ current directory.
 
 import os
 import shutil
-import json
 import argparse
+import pathlib
 
 from . import implementation
 
+
 def main():
     parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title='subcommands', dest='subcommand',
+        help="Use --help with any subcommand to see more details")
 
-    parser.add_argument('--add_package',
-        help="Add an already-installed, pure-Python package from current CPython environment "
-            "into current Brython project's ./Lib/site-packages")
+    # Init
+    init_parser = subparsers.add_parser('install', aliases=['init'],
+        help='Install Brython in an empty directory',
+        description='Initialize an empty directory with basic Brython files '
+                    '(brython.js, brython_stdlib.js, index.html etc)')
+    init_parser.add_argument('--install-dir', default=os.getcwd(),
+        help='Install Brython to this directory (default to current dir)')
 
-    parser.add_argument('--install', help='Install Brython in an empty directory',
+    # Update
+    update_parser = subparsers.add_parser('update',
+        help='Update Brython scripts (brython.js, brython_stdlib.js)',
+        description="Replace brython scripts in selected dir "
+                    "with latest known to brython-cli")
+
+    update_parser.add_argument('--update-dir',
+        help='Update Brython scripts in this directory '
+             '(default to current dir)')
+
+    # Add package
+    add_package_parser = subparsers.add_parser('add_package',
+        help="Add already-installed Python package to Brython project",
+        description="Add an already-installed, pure-Python package "
+                    "from current CPython environment "
+                    "into current Brython project's ./Lib/site-packages")
+
+    add_package_parser.add_argument('package', help="package name")
+    add_package_parser.add_argument('--dest-dir',
+        help="Optionally specify alternate destination dir")
+
+    # Make package
+    make_package_parser = subparsers.add_parser('make_package',
+        help="Make a browser loadable Python package script",
+        description="Make a loadable {package_name}.brython.js package file "
+                    "from regular python package")
+
+    make_package_parser.add_argument('package_name',
+        help="name used to import this package. as in (`import {package_name}`)")
+    make_package_parser.add_argument('--src-dir', metavar='SOURCE_DIR',
+        help="package source dir (defaults to current dir)")
+    make_package_parser.add_argument('--exclude-dirs', nargs='+', metavar='EXCLUDE_DIR',
+        help="directories under src-dir to exclude")
+    make_package_parser.add_argument('-o', '--output-path',
+        help="package file output path (defaults to {package_name}.brython.js in source dir)")
+
+    # Make modules
+    make_modules_parser = subparsers.add_parser('make_modules',
+        help="Create brython_modules.js with all the modules used by the application",
+        description="Create brython_modules.js with all the modules used by the application")
+
+    make_modules_parser.add_argument('-o', '--output-path',
+        help='Optionally specify modules file output path')
+
+    make_modules_parser.add_argument('--reset', help='Reset brython_modules.js to stdlib',
         action="store_true")
 
-    parser.add_argument('--make_dist', help='Make a Python distribution',
-        action="store_true")
+    # Server
+    start_server_parser = subparsers.add_parser('start_server',
+        help="Start development server",
+        description="Start development server")
 
-    parser.add_argument('--make_package', help='Make a loadable Python package')
+    start_server_parser.add_argument('port', nargs="?", default=8000, type=int,
+        help='Start development server on given port')
 
-    parser.add_argument('--make_file_system', help='Make a virtual file system')
+    # Others
+    make_dist_parser = subparsers.add_parser('make_dist',
+        help="Make a Python distribution",
+        description="Make a Python distribution")
 
-    parser.add_argument('--modules',
-        help='Create brython_modules.js with all the modules used by the application',
-        action="store_true")
-
-    parser.add_argument('--reset', help='Reset brython_modules.js to stdlib',
-        action="store_true")
-
-    parser.add_argument('--server', help='Start development server', nargs="?",
-        default="absent")
-
-    parser.add_argument('--update', help='Update Brython scripts',
-        action="store_true")
+    make_file_system_parser = subparsers.add_parser('make_file_system',
+        help="Make a virtual file system",
+        description="Make a virtual file system")
 
     parser.add_argument('--version', help='Brython version number',
         action="store_true")
@@ -47,15 +95,15 @@ def main():
     files = ['README.txt', 'demo.html', 'index.html',
         'brython.js', 'brython_stdlib.js', 'unicode.txt']
 
-    if args.add_package:
-        print('add package {}...'.format(args.add_package))
-        package = __import__(args.add_package)
+    if args.subcommand == 'add_package':
+        print('add package {}...'.format(args.package))
+        package = __import__(args.package)
         package_file = package.__file__
         package_dir = os.path.dirname(package_file)
         lib_dir = os.path.join(os.getcwd(), 'Lib')
         if not os.path.exists(lib_dir):
             os.mkdir(lib_dir)
-        dest_dir = os.path.join(lib_dir, 'site-packages')
+        dest_dir = os.path.join(lib_dir, 'site-packages') if (not args.dest_dir) else args.dest_dir
         if not os.path.exists(dest_dir):
             os.mkdir(dest_dir)
 
@@ -71,7 +119,7 @@ def main():
             print('done')
         elif not package_dir.split(os.sep)[-1] == "site-packages":
             print('copy folder', package_dir)
-            dest_dir = os.path.join(dest_dir, args.add_package)
+            dest_dir = os.path.join(dest_dir, args.package)
             if os.path.exists(dest_dir):
                 shutil.rmtree(dest_dir)
             shutil.copytree(package_dir, dest_dir)
@@ -80,13 +128,14 @@ def main():
             shutil.copyfile(package_file, os.path.join(dest_dir,
                 os.path.basename(package_file)))
 
-    if args.install:
+    if args.subcommand == 'install' or args.subcommand == 'init':
         print('Installing Brython {}'.format(implementation))
 
         data_path = os.path.join(os.path.dirname(__file__), 'data')
-        current_path_files = os.listdir(os.getcwd())
+        install_dir = args.install_dir
+        install_dir_files = os.listdir(install_dir)
 
-        if current_path_files and 'brython.js' in current_path_files:
+        if install_dir_files and 'brython.js' in install_dir_files:
             override = input(
                 'brython.js is already present in this directory.'
                 ' Override ? (Y/N)'
@@ -97,42 +146,51 @@ def main():
                 sys.exit()
 
         for path in os.listdir(data_path):
+            # note: here '/' is pathlib.Path join operator
+            dest_path = pathlib.Path(install_dir) / pathlib.Path(path)
             try:
-                shutil.copyfile(os.path.join(data_path, path), path)
+                shutil.copyfile(os.path.join(data_path, path), dest_path)
             except shutil.SameFileError:
                 print(f'{path} has not been moved. Are the same file.')
 
         print('done')
 
-    if args.update:
+    if args.subcommand == 'update':
         print('Update Brython scripts to version {}'.format(implementation))
+        # here '/' is Path join operator
+        data_path = pathlib.Path(os.path.dirname(__file__)) / 'data'
+        update_dir = pathlib.Path(args.update_dir)
 
-        data_path = os.path.join(os.path.dirname(__file__), 'data')
+        # Update only specific safe files, as user may have customized index.html etc
+        for path in ['brython.js', 'brython_stdlib.js']:
+            dest_path = pathlib.Path(update_dir) / pathlib.Path(path)
+            shutil.copyfile(os.path.join(data_path, path), dest_path)
 
-        for path in os.listdir(data_path):
-            shutil.copyfile(os.path.join(data_path, path), path)
+    if args.subcommand == 'make_modules':
+        if args.reset:
+            print('Reset brython_modules.js to local standard distribution')
+            stdlib_file_path = pathlib.Path.cwd() / 'brython_stdlib.js'
+            modules_file_path = (
+                args.output_path if args.output_path
+                else pathlib.Path.cwd() / 'brython_modules.js')
+            shutil.copyfile(stdlib_file_path, modules_file_path)
+        else:
+            print('Create brython_modules.js with all the modules used by the '
+                'application')
+            from . import list_modules
 
-    if args.reset:
-        print('Reset brython_modules.js to standard distribution')
-        shutil.copyfile(os.path.join(os.getcwd(), 'brython_stdlib.js'),
-            os.path.join(os.getcwd(), 'brython_modules.js'))
+            print('searching brython_stdlib.js...')
+            stdlib_dir, stdlib = list_modules.load_stdlib_sitepackages()
 
-    if args.modules:
-        print('Create brython_modules.js with all the modules used by the '
-            'application')
-        from . import list_modules
+            print('finding packages...')
+            user_modules = list_modules.load_user_modules()
+            finder = list_modules.ModulesFinder(stdlib=stdlib, user_modules=user_modules)
+            finder.inspect()
+            path = os.path.join(stdlib_dir, "brython_modules.js")
+            output_path = path if (not args.output_path) else args.output_path
+            finder.make_brython_modules(output_path)
 
-        print('searching brython_stdlib.js...')
-        stdlib_dir, stdlib = list_modules.load_stdlib_sitepackages()
-
-        print('finding packages...')
-        user_modules = list_modules.load_user_modules()
-        finder = list_modules.ModulesFinder(stdlib=stdlib, user_modules=user_modules)
-        finder.inspect()
-        path = os.path.join(stdlib_dir, "brython_modules.js")
-        finder.make_brython_modules(path)
-
-    if args.make_dist:
+    if args.subcommand == 'make_dist':
         print('Make a Python distribution for the application')
         from . import list_modules
 
@@ -148,7 +206,7 @@ def main():
         finder.make_setup()
         print('done')
 
-    if args.make_file_system:
+    if args.subcommand == 'make_file_system':
         print('Create a Javascript file for all the files in the directory')
         args_fs = args.make_file_system.split("#")
         if len(args_fs) > 2:
@@ -160,13 +218,16 @@ def main():
         make(vfs_name, prefix)
         print('done')
 
-    if args.make_package:
-        package_name = args.make_package
+    if args.subcommand == 'make_package':
+        package_name = args.package_name
+        package_path = args.src_dir
+        exclude_dirs = args.exclude_dirs
+        output_path = args.output_path
         from . import make_package
-        make_package.make(package_name, os.getcwd())
+        make_package.make(package_name, package_path, exclude_dirs, output_path)
         print("done")
 
-    if args.server != "absent":
+    if args.subcommand == 'start_server':
         # start development server
         import http.server
         import sysconfig
@@ -177,7 +238,7 @@ def main():
             def guess_type(self, path):
                 ctype = super().guess_type(path)
                 # in case the mimetype associated with .js in the Windows
-                # registery is not correctly set
+                # registry is not correctly set
                 if os.path.splitext(path)[1] == ".js":
                     ctype = "application/javascript"
                 return ctype
@@ -192,20 +253,21 @@ def main():
                         return os.path.join(cpython_site_packages, *elts[2:])
                 return super().translate_path(path)
 
-
-        # port to be used when the server runs locally
-        port = 8000 if args.server is None else int(args.server)
-
         print("Brython development server. "
-            "Not meant to be used in production.")
-        if args.server is None:
-            print("For a different port provide command-line option "
-                '"--server PORT".')
+              "Not meant to be used in production.")
+
+        print("For a different port provide command-line option "
+              "'--port PORT'.")
         print("Press CTRL+C to Quit.\n")
-        http.server.test(HandlerClass=Handler, port=port)
+        http.server.test(HandlerClass=Handler, port=args.port)
+
+    if args.subcommand is None:
+        if not args.version:
+            parser.print_help()
 
     if args.version:
         print('Brython version', implementation)
+
 
 if __name__ == "__main__":
     main()

--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -90,6 +90,38 @@ def main():
         help="Make a virtual file system",
         description="Make a virtual file system")
 
+    # # Note: This may be uncommented when compat mode is removed
+    # parser.add_argument('--version', help='Brython version number',
+    #     action="store_true")
+
+    # Compatibility (old style)
+    parser.add_argument('--add_package',
+        help="Add an already-installed, pure-Python package from current CPython environment "
+            "into current Brython project's ./Lib/site-packages")
+
+    parser.add_argument('--install', help='Install Brython in an empty directory',
+        action="store_true")
+
+    parser.add_argument('--make_dist', help='Make a Python distribution',
+        action="store_true")
+
+    parser.add_argument('--make_package', help='Make a loadable Python package')
+
+    parser.add_argument('--make_file_system', help='Make a virtual file system')
+
+    parser.add_argument('--modules',
+        help='Create brython_modules.js with all the modules used by the application',
+        action="store_true")
+
+    parser.add_argument('--reset', help='Reset brython_modules.js to stdlib',
+        action="store_true")
+
+    parser.add_argument('--server', help='Start development server', nargs="?",
+        default="absent")
+
+    parser.add_argument('--update', help='Update Brython scripts',
+        action="store_true")
+
     parser.add_argument('--version', help='Brython version number',
         action="store_true")
 
@@ -265,11 +297,176 @@ def main():
         http.server.test(HandlerClass=Handler, port=args.port, bind=args.bind)
 
     if args.subcommand is None:
-        if not args.version:
+        # # Note: This section may be uncommented when compat mode is removed
+        # Arguments independent of subcommand
+        # if args.version:
+        #     print('Brython version', implementation)
+
+        # For totally clueless -> print_help
+        import sys
+        if len(sys.argv[1:]) == 0:
             parser.print_help()
 
-    if args.version:
-        print('Brython version', implementation)
+        # Compatibility mode (old style)
+        if args.add_package:
+            print('add package {}...'.format(args.add_package))
+            package = __import__(args.add_package)
+            package_file = package.__file__
+            package_dir = os.path.dirname(package_file)
+            lib_dir = os.path.join(os.getcwd(), 'Lib')
+            if not os.path.exists(lib_dir):
+                os.mkdir(lib_dir)
+            dest_dir = os.path.join(lib_dir, 'site-packages')
+            if not os.path.exists(dest_dir):
+                os.mkdir(dest_dir)
+
+            if os.path.splitext(package_dir)[1] == '.egg':
+                import zipfile
+                zf = zipfile.ZipFile(package_dir)
+                for info in zf.infolist():
+                    if info.filename.startswith(('__pycache__', 'EGG-INFO')):
+                        continue
+                    zf.extract(info, dest_dir)
+                    print('extract', info.filename)
+                zf.close()
+                print('done')
+            elif not package_dir.split(os.sep)[-1] == "site-packages":
+                print('copy folder', package_dir)
+                dest_dir = os.path.join(dest_dir, args.add_package)
+                if os.path.exists(dest_dir):
+                    shutil.rmtree(dest_dir)
+                shutil.copytree(package_dir, dest_dir)
+            else:
+                print('copy single file', package_file)
+                shutil.copyfile(package_file, os.path.join(dest_dir,
+                    os.path.basename(package_file)))
+
+        if args.install:
+            print('Installing Brython {}'.format(implementation))
+
+            data_path = os.path.join(os.path.dirname(__file__), 'data')
+            current_path_files = os.listdir(os.getcwd())
+
+            if current_path_files and 'brython.js' in current_path_files:
+                override = input(
+                    'brython.js is already present in this directory.'
+                    ' Override ? (Y/N)'
+                )
+                if override.lower() != 'y':
+                    import sys
+                    print('exiting')
+                    sys.exit()
+
+            for path in os.listdir(data_path):
+                try:
+                    shutil.copyfile(os.path.join(data_path, path), path)
+                except shutil.SameFileError:
+                    print(f'{path} has not been moved. Are the same file.')
+
+            print('done')
+
+        if args.update:
+            print('Update Brython scripts to version {}'.format(implementation))
+
+            data_path = os.path.join(os.path.dirname(__file__), 'data')
+
+            for path in os.listdir(data_path):
+                shutil.copyfile(os.path.join(data_path, path), path)
+
+        if args.reset:
+            print('Reset brython_modules.js to standard distribution')
+            shutil.copyfile(os.path.join(os.getcwd(), 'brython_stdlib.js'),
+                os.path.join(os.getcwd(), 'brython_modules.js'))
+
+        if args.modules:
+            print('Create brython_modules.js with all the modules used by the '
+                'application')
+            from . import list_modules
+
+            print('searching brython_stdlib.js...')
+            stdlib_dir, stdlib = list_modules.load_stdlib_sitepackages()
+
+            print('finding packages...')
+            user_modules = list_modules.load_user_modules()
+            finder = list_modules.ModulesFinder(stdlib=stdlib, user_modules=user_modules)
+            finder.inspect()
+            path = os.path.join(stdlib_dir, "brython_modules.js")
+            finder.make_brython_modules(path)
+
+        if args.make_dist:
+            print('Make a Python distribution for the application')
+            from . import list_modules
+
+            print('searching brython_stdlib.js...')
+            stdlib_dir, stdlib = list_modules.load_stdlib_sitepackages()
+
+            print('finding packages...')
+            user_modules = list_modules.load_user_modules()
+            finder = list_modules.ModulesFinder(stdlib=stdlib, user_modules=user_modules)
+            finder.inspect()
+            path = os.path.join(stdlib_dir, "brython_modules.js")
+            finder.make_brython_modules(path)
+            finder.make_setup()
+            print('done')
+
+        if args.make_file_system:
+            print('Create a Javascript file for all the files in the directory')
+            args_fs = args.make_file_system.split("#")
+            if len(args_fs) > 2:
+                raise ValueError("--make_file_systems expects at most 2 "
+                    "arguments, got " + str(len(args_fs)))
+            vfs_name = args_fs[0]
+            prefix = args_fs[1] if len(args_fs) > 1 else None
+            from .make_file_system import make
+            make(vfs_name, prefix)
+            print('done')
+
+        if args.make_package:
+            package_name = args.make_package
+            from . import make_package
+            make_package.make(package_name, os.getcwd())
+            print("done")
+
+        if args.server != "absent":
+            # start development server
+            import http.server
+            import sysconfig
+            cpython_site_packages = sysconfig.get_path("purelib")
+
+            class Handler(http.server.CGIHTTPRequestHandler):
+
+                def guess_type(self, path):
+                    ctype = super().guess_type(path)
+                    # in case the mimetype associated with .js in the Windows
+                    # registery is not correctly set
+                    if os.path.splitext(path)[1] == ".js":
+                        ctype = "application/javascript"
+                    return ctype
+
+                def translate_path(self, path):
+                    """Map /cpython_site_packages to local CPython site-packages
+                    directory."""
+                    elts = path.split('/')
+                    if len(elts) > 1 and elts[0] == '':
+                        if elts[1] == 'cpython_site_packages':
+                            elts[-1] = elts[-1].split("?")[0]
+                            return os.path.join(cpython_site_packages, *elts[2:])
+                    return super().translate_path(path)
+
+
+            # port to be used when the server runs locally
+            port = 8000 if args.server is None else int(args.server)
+
+            print("Brython development server. "
+                "Not meant to be used in production.")
+            if args.server is None:
+                print("For a different port provide command-line option "
+                    '"--server PORT".')
+            print("Press CTRL+C to Quit.\n")
+            http.server.test(HandlerClass=Handler, port=port)
+
+        if args.version:
+            print('Brython version', implementation)
 
 
 if __name__ == "__main__":

--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -308,7 +308,12 @@ def main():
             parser.print_help()
 
         # Compatibility mode (old style)
+        import warnings
+
         if args.add_package:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('add package {}...'.format(args.add_package))
             package = __import__(args.add_package)
             package_file = package.__file__
@@ -342,6 +347,9 @@ def main():
                     os.path.basename(package_file)))
 
         if args.install:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('Installing Brython {}'.format(implementation))
 
             data_path = os.path.join(os.path.dirname(__file__), 'data')
@@ -366,6 +374,9 @@ def main():
             print('done')
 
         if args.update:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('Update Brython scripts to version {}'.format(implementation))
 
             data_path = os.path.join(os.path.dirname(__file__), 'data')
@@ -374,11 +385,17 @@ def main():
                 shutil.copyfile(os.path.join(data_path, path), path)
 
         if args.reset:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('Reset brython_modules.js to standard distribution')
             shutil.copyfile(os.path.join(os.getcwd(), 'brython_stdlib.js'),
                 os.path.join(os.getcwd(), 'brython_modules.js'))
 
         if args.modules:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('Create brython_modules.js with all the modules used by the '
                 'application')
             from . import list_modules
@@ -394,6 +411,9 @@ def main():
             finder.make_brython_modules(path)
 
         if args.make_dist:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('Make a Python distribution for the application')
             from . import list_modules
 
@@ -410,6 +430,9 @@ def main():
             print('done')
 
         if args.make_file_system:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             print('Create a Javascript file for all the files in the directory')
             args_fs = args.make_file_system.split("#")
             if len(args_fs) > 2:
@@ -422,12 +445,18 @@ def main():
             print('done')
 
         if args.make_package:
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             package_name = args.make_package
             from . import make_package
             make_package.make(package_name, os.getcwd())
             print("done")
 
         if args.server != "absent":
+            warnings.warn("Options style primary args may be deprecated soon. "
+                          "Please use subcommands instead (see '--help')",
+                          DeprecationWarning)
             # start development server
             import http.server
             import sysconfig

--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -78,10 +78,13 @@ def main():
     start_server_parser.add_argument('port', nargs="?", default=8000, type=int,
         help='Start development server on given port')
 
+    start_server_parser.add_argument('--bind', metavar='ADDRESS', default='localhost',
+        help='Address on which server should listen (default: localhost)')
+
     # Others
     make_dist_parser = subparsers.add_parser('make_dist',
-        help="Make a Python distribution",
-        description="Make a Python distribution")
+        help="Make a Python (PyPI) distribution",
+        description="Make a Python distribution https://brython.info/static_doc/en/deploy.html")
 
     make_file_system_parser = subparsers.add_parser('make_file_system',
         help="Make a virtual file system",
@@ -259,7 +262,7 @@ def main():
         print("For a different port provide command-line option "
               "'--port PORT'.")
         print("Press CTRL+C to Quit.\n")
-        http.server.test(HandlerClass=Handler, port=args.port)
+        http.server.test(HandlerClass=Handler, port=args.port, bind=args.bind)
 
     if args.subcommand is None:
         if not args.version:


### PR DESCRIPTION
Use subcommands for better options delineating
```
[~]$ brython-cli 
usage: brython-cli [-h] [--version] {install,init,update,add_package,make_package,make_modules,start_server,make_dist,make_file_system} ...

optional arguments:
  -h, --help            show this help message and exit
  --version             Brython version number

subcommands:
  {install,init,update,add_package,make_package,make_modules,start_server,make_dist,make_file_system}
                        Use --help with any subcommand to see more details
    install (init)      Install Brython in an empty directory
    update              Update Brython scripts (brython.js, brython_stdlib.js)
    add_package         Add already-installed Python package to Brython project
    make_package        Make a browser loadable Python package script
    make_modules        Create brython_modules.js with all the modules used by the application
    start_server        Start development server
    make_dist           Make a Python distribution
    make_file_system    Make a virtual file system

```

```
[~]$ brython-cli add_package --help
usage: brython-cli add_package [-h] [--dest-dir DEST_DIR] package

Add an already-installed, pure-Python package from current CPython environment into current Brython project's ./Lib/site-packages

positional arguments:
  package              package name

optional arguments:
  -h, --help           show this help message and exit
  --dest-dir DEST_DIR  Optionally specify alternate destination dir
```

```
[~]$ brython-cli make_package --help
usage: brython-cli make_package [-h] [--src-dir SOURCE_DIR]
                                [--exclude-dirs EXCLUDE_DIR [EXCLUDE_DIR ...]] [-o OUTPUT_PATH]
                                package_name

Make a loadable {package_name}.brython.js package file from regular python package

positional arguments:
  package_name          name used to import this package. as in (`import {package_name}`)

optional arguments:
  -h, --help            show this help message and exit
  --src-dir SOURCE_DIR  package source dir (defaults to current dir)
  --exclude-dirs EXCLUDE_DIR [EXCLUDE_DIR ...]
                        directories under src-dir to exclude
  -o OUTPUT_PATH, --output-path OUTPUT_PATH
                        package file output path (defaults to {package_name}.brython.js in source dir)
```

This structure change is (hopefully) a improvement to the current cli interface structure. 
Subcommands designate *actions*. And options are used to pass parameters to those actions.

Do give it a try. Open to to suggestions.
We can discuss here if there's anything you'd like changed and if you'd like to see this merged eventually.  
🤞

