### PR TITLE
Fix Python to Javascript conversion functions

### DIFF
--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -310,7 +310,7 @@ $B.python_to_js = function(src, script_id){
     if(!$B.use_VFS){$B.meta_path.shift()}
     if(script_id === undefined){script_id = "__main__"}
 
-    var root = __BRYTHON__.py2js(src, script_id, script_id),
+    var root = __BRYTHON__.py2js({src, filename: '<string>'}, script_id, script_id, __BRYTHON__.builtins_scope),
         js = root.to_js()
 
     js = "(function() {\n var $locals_" + script_id + " = {}\n" + js + "\n}())"

--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -510,7 +510,7 @@
             if(module_name === undefined){
                 module_name = '__main__' + $B.UUID()
             }
-            var js = $B.py2js(src, module_name, module_name,
+            var js = $B.py2js({src, filename: '<string>'}, module_name, module_name,
                 $B.builtins_scope).to_js()
             return $B.format_indent(js, 0)
         },


### PR DESCRIPTION
Currently, the "Javascript" button on the website is broken:

![Screen Shot 2022-06-15 at 3 07 03 PM](https://user-images.githubusercontent.com/868327/173905467-95eb9c47-176d-4b29-9bd5-38a749b1e210.png)

This PR fixes that, though I'm not sure it's the cleanest fix. Setting the filename of the source object causes Brython to correctly generate a scope object. 