### PR TITLE
Add $B.UndefinedType.__str__

### DIFF
--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -364,6 +364,7 @@
     $B.UndefinedType.__repr__ = function(self){
         return "<Javascript undefined>"
     }
+    $B.UndefinedType.__str__ = $B.UndefinedType.__repr__;
 
     $B.Undefined = {__class__: $B.UndefinedType}
 

--- a/www/tests/brython_test_utils/__init__.py
+++ b/www/tests/brython_test_utils/__init__.py
@@ -151,7 +151,7 @@ def run(src, file_path=None):
     except Exception as exc:
         #msg = traceback.format_exc()
         #print(msg, file=sys.stderr)
-        console.log('exc in run', exc.args)
+        console.log('exc in run', getattr(exc, 'args', None))
         trace_exc(sys._getframe())
         state = 0
     t1 = time.perf_counter()


### PR DESCRIPTION
I looked into why the test_jsobjects.py tests are failing on master. I couldn't figure it out :) But I did make these two little changes that were causing spurious errors at least. 

Looks like `javascript.import_js('js_test.js')` is failing in test_jsobjects.py, for what it's worth. 