### PR TITLE
Fix undefined name 'sys' in www/src/Lib/external_import.py

### DIFF
--- a/www/src/Lib/external_import.py
+++ b/www/src/Lib/external_import.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from browser import doc
 import urllib.request
 


### PR DESCRIPTION
`www/src/Lib/external_import.py` uses `sys` on lines 53, 55, and 84 but it is never imported or defined.