### PR TITLE
Add range info for positional argument syntax error

### DIFF
--- a/www/src/py2js.js
+++ b/www/src/py2js.js
@@ -1613,10 +1613,14 @@ $CallCtx.prototype.ast = function(){
             }else{
                 if(res.keywords.length > 0){
                     if(res.keywords[0].arg){
-                        raise_syntax_error(this,
+                        raise_syntax_error_known_range(this,
+                            item.position,
+                            last_position(item),
                             'positional argument follows keyword argument')
                     }else{
-                        raise_syntax_error(this,
+                        raise_syntax_error_known_range(this,
+                            item.position,
+                            last_position(item),
                             'positional argument follows keyword argument unpacking')
                     }
                 }


### PR DESCRIPTION
This fixes the first bug in #2008 