### PR TITLE
Remove make_ast_classes.py from flake8 excludes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ jobs:
       before_install: pip install --upgrade pip
       before_script: pip install flake8
       script:
-        - EXCLUDE=./.*,scripts/make_ast_classes.py,www/src/Lib,www/tests
+        - EXCLUDE=./.*,www/src/Lib,www/tests
         # stop the build if there are Python syntax errors or undefined names
         - flake8 --builtins=__BRYTHON__ --exclude=$EXCLUDE --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
`scripts/make_ast_classes.py` was fixed in #2004 so it can be removed from flake8's excluded list.