### PR TITLE
Detect NW.js environment as browser-like (due to lack of module object)

### DIFF
--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -13,7 +13,8 @@ try{
 $B.isWebWorker = ('undefined' !== typeof WorkerGlobalScope) &&
                   ("function" === typeof importScripts) &&
                   (navigator instanceof WorkerNavigator)
-$B.isNode = (typeof process !=='undefined') && (process.release.name==='node')
+$B.isNode = (typeof process !=='undefined') && (process.release.name==='node') 
+    && (process.__nwjs!==1)
 
 
 var _window


### PR DESCRIPTION
NW.js (https://nwjs.io/) was based on Node, but has no module object, but like browser in other aspects