### PR TITLE
Updating Version in Pipfile and correction bryton.css file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,4 +8,4 @@ url = "https://pypi.python.org/simple"
 [packages]
 
 [requires]
-python_version = "3.10"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0bd6a400589d63887497a4d4f8ba0dc7bca2757987c90cb8e4e4fc19452bc7b0"
+            "sha256": "a780878b317b63cca0caab035df0712d62485e45d0c1adbfd58b9976f1cac7b6"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/www/brython.css
+++ b/www/brython.css
@@ -170,7 +170,7 @@ h1.brython{
 .logo {
   font-family: libra_bt;
   font-size: 3em;
-  color:var(--dark-2)
+  color:var(--dark-2);
   background-color:var(--clear-2);
   padding: 1em 1em 0.5em 1em;
   width:15%;


### PR DESCRIPTION
I have updated the pipfile python version to the latest i.e python3.11 as Brython's latest version is 3.11 and it was not passing the version check for make_dist.py in the src directory.
The second change was  a small correction in the CSS file 