### PR TITLE
fixed async-for bug #2148

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -1554,6 +1554,7 @@ $B.ast.For.prototype.to_js = function(scopes){
         js += `var iter_${id} = ${iter},\n` +
                  `type_${id} = _b_.type.$factory(iter_${id})\n` +
             `iter_${id} = $B.$call($B.$getattr(type_${id}, "__aiter__"))(iter_${id})\n` +
+            `type_${id} = _b_.type.$factory(iter_${id})\n` +
             `var next_func_${id} = $B.$call(` +
             `$B.$getattr(type_${id}, '__anext__'))\n` +
             `while(true){\n`+


### PR DESCRIPTION
manually passed test case provided in issue #2148 (successfully calls the right `__anext__` method), and the entire test suite passes.