### PR TITLE
Fix float->int conversion; fix make_dist on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
       before_install:
         - npm install testem
         - ./node_modules/.bin/testem launchers
+        - apt install python3.11
 
       before_script:
         - (cd scripts && python3.11 make_doc.py)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ jobs:
         apt:
           packages:
             - libnss3
+            - python3.11
       services:
         - xvfb
       before_install:
         - npm install testem
         - ./node_modules/.bin/testem launchers
-        - apt install python3.11
 
       before_script:
         - (cd scripts && python3.11 make_doc.py)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
         - ./node_modules/.bin/testem launchers
 
       before_script:
-        - (cd scripts && python3.10 make_doc.py)
-        - (cd scripts && python3.10 make_dist.py)
+        - (cd scripts && python3.11 make_doc.py)
+        - (cd scripts && python3.11 make_dist.py)
 
       script:
         # Some day, put back Chrome or "Headless Chrome" as well. For some reason
@@ -29,7 +29,7 @@ jobs:
         - ./node_modules/.bin/testem --launch Firefox -t www/tests/run_tests.html ci
 
     - language: python
-      python: '3.10'
+      python: '3.11'
       before_install: pip install --upgrade pip
       before_script: pip install flake8
       script:

--- a/scripts/make_dist.py
+++ b/scripts/make_dist.py
@@ -13,7 +13,7 @@ cpython_version = sys.version_info
 if cpython_version[0] != version[0] or \
         cpython_version[1] != version [1]:
     print("This script requires Python {}.{}".format(*version[:2]))
-    sys.exit()
+    sys.exit(1)
 
 # version name
 vname = '.'.join(str(x) for x in implementation[:3])

--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -810,7 +810,7 @@ float.__int__ = function(self){
                    res_num :
                    $B.fast_long_int(res)
     }
-    return Math.floor(self.value)
+    return Math.trunc(self.value)
 }
 
 float.is_integer = function(self){

--- a/www/tests/test_numbers.py
+++ b/www/tests/test_numbers.py
@@ -765,5 +765,7 @@ assert int('9' + chr(int('17E4', 16)) + 'b', 16) == 2379
 
 # issue 2228
 assert int(0.00005) == 0
+assert int(3.9) == 3
+assert int(-3.9) == -3
 
 print('passed all tests...')


### PR DESCRIPTION
* make_dist.py was failing on Travis but not causing the build to fail, so I added a non-zero exit code when it is run with the wrong version of Python
* int(-3.5) used to return -4 instead of -3, so I fixed that.