### PR TITLE
Convert remaining NameError.$factory to $B.name_error

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -517,11 +517,11 @@ $B.resolve_global = function(name, _frames){
     if(builtins_scope.locals.has(name)){
         return _b_[name]
     }
-    throw _b_.NameError.$factory(name)
+    throw $B.name_error(name)
 }
 
 $B.own_class_name = function(name){
-    throw _b_.NameError.$factory(name)
+    throw $B.name_error(name)
 }
 
 var $operators = $B.op2method.subset("all") // in py2js.js

--- a/www/src/py_exceptions.js
+++ b/www/src/py_exceptions.js
@@ -590,7 +590,7 @@ _b_.UnboundLocalError.__str__ = function(self){
 $B.set_func_names(_b_.UnboundLocalError, 'builtins')
 
 // Shortcut to create a NameError
-$B.name_error = function(name, obj){
+$B.name_error = function(name){
     var exc = _b_.NameError.$factory(`name '${name}' is not defined`)
     exc.name = name
     exc.$stack = $B.frames_stack.slice()


### PR DESCRIPTION
Following up on e01daaf799d19c55b956db06742ecf6f283c1f57, this changes a few more calls to NameError.$factory to use $B.name_error. I also removed an unused argument from $B.name_error.

It seems like resolve_global isn't used by the tests, maybe because they use exec (?), so I don't see how to add an automated test for this. 