### PR TITLE
Fix base not being search recursivelly in webcomponent.define()

### DIFF
--- a/www/src/brython.js
+++ b/www/src/brython.js
@@ -148,9 +148,9 @@ $B.stdlib_module_names=Object.keys($B.stdlib)})(__BRYTHON__)
 ;
 __BRYTHON__.implementation=[3,12,0,'dev',0]
 __BRYTHON__.version_info=[3,12,0,'final',0]
-__BRYTHON__.compiled_date="2023-10-27 16:05:37.816388"
-__BRYTHON__.timestamp=1698415537816
-__BRYTHON__.builtin_module_names=["_aio","_ajax","_ast","_base64","_binascii","_io_classes","_json","_jsre","_locale","_multiprocessing","_posixsubprocess","_profile","_random","_sre","_sre_utils","_string","_strptime","_svg","_symtable","_tokenize","_webcomponent","_webworker","_zlib_utils","array","builtins","dis","encoding_cp932","hashlib","html_parser","marshal","math","modulefinder","posix","python_re","python_re_new","unicodedata"]
+__BRYTHON__.compiled_date="2023-10-27 20:11:25.832720"
+__BRYTHON__.timestamp=1698430285832
+__BRYTHON__.builtin_module_names=["_aio","_ajax","_ast","_base64","_binascii","_io_classes","_json","_jsre","_locale","_multiprocessing","_posixsubprocess","_profile","_random","_sre","_sre_utils","_string","_strptime","_svg","_symtable","_tokenize","_webcomponent","_webworker","_zlib_utils","array","builtins","dis","encoding_cp932","hashlib","html_parser","marshal","math","modulefinder","posix","python_re","unicodedata"]
 ;
 ;(function($B){var _b_=$B.builtins
 $B.is_identifier=function(category,cp){
@@ -5259,9 +5259,9 @@ for(let i=0;i < nb_named_defaults;++i)
 result[PARAMS_NAMES[offset++]]=named_default_values[i];
 return result;}
 let kwargs_defaults=$INFOS.__kwdefaults__.$jsobj;
-if(kwargs_defaults===undefined || kwargs_defaults==null ){kwargs_defaults=$INFOS.__kwdefaults__.$strings;
-if(kwargs_defaults===undefined || kwargs_defaults==null )
-kwargs_defaults={}}
+if(kwargs_defaults===undefined ||kwargs_defaults===null ){kwargs_defaults=$INFOS.__kwdefaults__.$strings;
+if(kwargs_defaults===undefined ||kwargs_defaults===null )
+kwargs_defaults={};}
 const PARAMS_POSONLY_COUNT=$CODE.co_posonlyargcount;
 const PARAMS_POS_DEFAULTS_MAXID=PARAMS_POS_DEFAULTS_COUNT+PARAMS_POS_DEFAULTS_OFFSET;
 if(offset < PARAMS_POSONLY_COUNT ){if(offset < PARAMS_POS_DEFAULTS_OFFSET ){args0(fct,args);

--- a/www/src/libs/_webcomponent.js
+++ b/www/src/libs/_webcomponent.js
@@ -23,12 +23,17 @@ function define(tag_name, cls, options){
             // ignore
         }
     }else{
-        for(var base of cls.__bases__){
-            if(base.__module__ == 'browser.html'){
-                _extends = base.__name__.toLowerCase()
-                break
-            }
-        }
+        let stack = [...cls.__bases__];
+        while(stack.length) {
+        	base = stack.pop();
+		if(base.__module__ === 'browser.html'){
+		        _extends = base.__name__.toLowerCase()
+		        break
+		}
+		    
+		stack.push(...base.__bases__);
+	}
+	console.log("FOUND", _extends);
     }
 
     if(_extends){

--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -222,11 +222,11 @@ function args0_NEW(fct, args) {
     }
 
     let kwargs_defaults = $INFOS.__kwdefaults__.$jsobj;
-        if( kwargs_defaults === undefined  || kwargs_defaults == null ) {
+        if( kwargs_defaults === undefined || kwargs_defaults === null ) {
 
             kwargs_defaults = $INFOS.__kwdefaults__.$strings;
-            if( kwargs_defaults === undefined  || kwargs_defaults == null )
-                kwargs_defaults = {}
+            if( kwargs_defaults === undefined || kwargs_defaults === null )
+                kwargs_defaults = {};
         }
     //const kwargs_defaults= $INFOS.__kwdefaults__.$jsobj ?? $INFOS.__kwdefaults__.$strings ?? {}; // costs a little...
 

--- a/www/src/version_info.js
+++ b/www/src/version_info.js
@@ -1,7 +1,7 @@
 __BRYTHON__.implementation = [3, 12, 0, 'dev', 0]
 __BRYTHON__.version_info = [3, 12, 0, 'final', 0]
-__BRYTHON__.compiled_date = "2023-10-27 16:05:37.816388"
-__BRYTHON__.timestamp = 1698415537816
+__BRYTHON__.compiled_date = "2023-10-27 20:11:25.832720"
+__BRYTHON__.timestamp = 1698430285832
 __BRYTHON__.builtin_module_names = ["_aio",
     "_ajax",
     "_ast",
@@ -36,5 +36,4 @@ __BRYTHON__.builtin_module_names = ["_aio",
     "modulefinder",
     "posix",
     "python_re",
-    "python_re_new",
     "unicodedata"]

--- a/www/test.html
+++ b/www/test.html
@@ -1,0 +1,25 @@
+<html>
+
+<head>
+    <script src="./src/brython.js"
+            crossorigin="anonymous" defer></script>
+    <script type="text/python">
+        
+        from browser import html, webcomponent;
+
+        class MyDivA(html.DIV):
+            def __init__(self):
+                self <= "A"
+
+        class MyDivB(MyDivA):
+            def __init__(self):
+                self <= "B"
+
+        webcomponent.define("my-div_a", MyDivA)
+
+        webcomponent.define("my-div_b", MyDivB)
+    </script>
+</head>
+    <div is="my-div_a"></div>
+    <div is="my-div_b"></div>
+</html>


### PR DESCRIPTION
Fix base not being search recursivelly in webcomponent.define() related to #2234
+ Fix a strange JS error in py_utils.js

To test it (on Chromium):
````html
<html>

<head>
    <script src="./src/brython.js"
            crossorigin="anonymous" defer></script>
    <script type="text/python">
        
        from browser import html, webcomponent;

        class MyDivA(html.DIV):
            def __init__(self):
                self <= "A"

        class MyDivB(MyDivA): # indirect inheritance was not working previously.
            def __init__(self):
                self <= "B"

        webcomponent.define("my-div_a", MyDivA)

        webcomponent.define("my-div_b", MyDivB)
    </script>
</head>
    <div is="my-div_a"></div>
    <div is="my-div_b"></div>
</html>
````