### PR TITLE
Fix issue #1913 (server open to outside world by default) by adding new --ip option to server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -219,6 +219,7 @@ class CompressedHandler(CGIHTTPRequestHandler):
 # port to be used when the server runs locally
 parser = argparse.ArgumentParser()
 parser.add_argument('--port', help="The port to be used by the local server")
+parser.add_argument('--ip', help="The IP address to be used by the local server")
 
 # generate docs?
 # when testing new code on your repo it is not necessary to generate docs all
@@ -231,6 +232,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 port = int(args.port) if args.port else 8000
+ip   = str(args.ip) if args.port else "127.0.0.1"
 
 if not args.no_docs:
     # generate static doc pages if not already present
@@ -246,7 +248,7 @@ os.chdir(os.path.join(os.getcwd(), 'www'))
 
 cgi_dir = os.path.join(os.path.dirname(os.getcwd()), 'cgi-bin')
 
-server_address, handler = ('', port), CompressedHandler
+server_address, handler = (ip, port), CompressedHandler
 httpd = socketserver.ThreadingTCPServer(server_address, handler)
 httpd.server_name = "Brython built-in server"
 httpd.server_port = port


### PR DESCRIPTION
Fix #1913.

Usage :
````
python3 server.py # listen on 127.0.0.1 only (secure)
python3 server.py --ip 0.0.0.0 # listen on all interfaces (old behavior)
python3 server.py --ip 192.168.1.1 # listen on a given IP address.
````