### PR TITLE
Tried to fix issue 2249

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -348,10 +348,15 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
         if(pyobj.$is_async){
             // issue 2251 : calling the Python async function in Javascript
             // returns a Promise
-            return function(){
+            const jsobj = function(){
                 var res = pyobj.apply(null, arguments)
                 return $B.coroutine.send(res)
-            }
+            };
+            
+            pyobj[JSOBJ] = jsobj;
+            jsobj[PYOBJ] = pyobj;
+            
+            return jsobj
         }
         // Transform into a Javascript function
         var f = function(){

--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -168,15 +168,18 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this){
     	// set it as non-enumerable, prevent issue when looping on it in JS.
         Object.defineProperty(jsobj, "$is_js_array", {value: true});
         return jsobj // $B.$list(jsobj.map(jsobj2pyobj))
-    }else if(typeof jsobj === 'number'){
+    }
+    if(typeof jsobj === 'number'){
        if(jsobj % 1 === 0){ //TODO: dangerous, it can also be a float with no decimals.
            return _b_.int.$factory(jsobj)
        }
        // for now, lets assume a float
        return _b_.float.$factory(jsobj)
-    }else if(typeof jsobj == "string"){
+    }
+    if(typeof jsobj == "string"){
         return $B.String(jsobj)
-    }else if(typeof jsobj == "function"){
+    }
+    if(typeof jsobj == "function"){
         // transform Python arguments to equivalent JS arguments
         _this = _this === undefined ? null : _this
         var res = function(){
@@ -214,7 +217,8 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
     // conversion of a Python object into a Javascript object
     if(pyobj === true || pyobj === false){
         return pyobj
-    }else if(pyobj === $B.Undefined){
+    }
+    if(pyobj === $B.Undefined){
         return undefined
     }
 
@@ -232,19 +236,22 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
         }
         return pyobj.js
 
-    }else if(klass === $B.DOMNode ||
+    }
+    if(klass === $B.DOMNode ||
             klass.__mro__.indexOf($B.DOMNode) > -1){
 
         // instances of DOMNode or its subclasses are transformed into the
         // underlying DOM element
         return pyobj
 
-    }else if([_b_.list, _b_.tuple].indexOf(klass) > -1){
+    }
+    if([_b_.list, _b_.tuple].indexOf(klass) > -1){
 
         // Python list : transform its elements
         return pyobj.map(pyobj2jsobj)
 
-    }else if(klass === _b_.dict || _b_.issubclass(klass, _b_.dict)){
+    }
+    if(klass === _b_.dict || _b_.issubclass(klass, _b_.dict)){
 
         // Python dictionaries are transformed into a Javascript object
         // whose attributes are the dictionary keys
@@ -265,18 +272,21 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
         }
         return jsobj
 
-    }else if(klass === _b_.str){
+    }
+    if(klass === _b_.str){
 
         // Python strings are converted to the underlying value
         return pyobj.valueOf()
 
-    }else if(klass === _b_.float){
+    }
+    if(klass === _b_.float){
 
         // floats are implemented as
         // {__class__: _b_.float, value: <JS number>}
         return pyobj.value
 
-    }else if(klass === $B.function || klass === $B.method){
+    }
+    if(klass === $B.function || klass === $B.method){
         if(pyobj.prototype &&
                 pyobj.prototype.constructor === pyobj &&
                 ! pyobj.$is_func){
@@ -313,10 +323,8 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
             }
         }
         return f
-    }else{
-        // other types are left unchanged
-        return pyobj
     }
+    return pyobj
 }
 
 $B.JSConstructor = JSConstructor

--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -148,7 +148,6 @@ JSConstructor.$factory = function(obj){
 }
 
 
-
 var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this){
     // If _this is passed and jsobj is a function, the function is called
     // with built-in value `this` set to _this
@@ -160,7 +159,8 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this){
 
     if(jsobj === undefined){
         return $B.Undefined
-    }else if(jsobj === null){
+    }
+    if(jsobj === null){
         return null
     }
 
@@ -183,9 +183,9 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this){
         // transform Python arguments to equivalent JS arguments
         _this = _this === undefined ? null : _this
         var res = function(){
-            var args = []
-            for(var i = 0, len = arguments.length; i < len; i++){
-                args.push(pyobj2jsobj(arguments[i]))
+            var args = new Array(arguments.length);
+            for(var i = 0, len = arguments.length; i < len; ++i){
+                args[i] = pyobj2jsobj(arguments[i]);
             }
             try{
                 return jsobj2pyobj(jsobj.apply(_this, args))
@@ -261,10 +261,10 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
         var jsobj = {}
         for(var entry of _b_.dict.$iter_items_with_hash(pyobj)){
             var key = entry.key
-            if(typeof key != "string"){
+            if(typeof key !== "string"){
                 key = _b_.str.$factory(key)
             }
-            if(typeof entry.value == 'function'){
+            if(typeof entry.value === 'function'){
                 // set "this" to jsobj
                 entry.value.bind(jsobj)
             }
@@ -306,9 +306,9 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj){
         var f = function(){
             try{
                 // transform JS arguments to Python arguments
-                var args = []
-                for(var i = 0; i < arguments.length; i++){
-                    args.push(jsobj2pyobj(arguments[i]))
+                var args = new Array(arguments.length);
+                for(var i = 0; i < arguments.length; ++i){
+                    args[i] = jsobj2pyobj(arguments[i]);
                 }
                 // Apply Python arguments to Python function
                 if(pyobj.prototype.constructor === pyobj && ! pyobj.$is_func){

--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -168,7 +168,7 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this){
         jsobj.$is_js_array = true
         return jsobj // $B.$list(jsobj.map(jsobj2pyobj))
     }else if(typeof jsobj === 'number'){
-       if(jsobj.toString().indexOf('.') == -1){
+       if(jsobj % 1 === 0){ //TODO: dangerous, it can also be a float with no decimals.
            return _b_.int.$factory(jsobj)
        }
        // for now, lets assume a float

--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -165,7 +165,8 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this){
     }
 
     if(Array.isArray(jsobj)){
-        jsobj.$is_js_array = true
+    	// set it as non-enumerable, prevent issue when looping on it in JS.
+        Object.defineProperty(jsobj, "$is_js_array", {value: true});
         return jsobj // $B.$list(jsobj.map(jsobj2pyobj))
     }else if(typeof jsobj === 'number'){
        if(jsobj % 1 === 0){ //TODO: dangerous, it can also be a float with no decimals.


### PR DESCRIPTION
On Brython <=> JS object conversions :
- Some optimizations
- Some bug fixes

Issue #2249 not fixed.
I think we really need to implement the prototype substitution, without it Brython <=> JS object conversions is chaotic.

Conversions of Arrays/Tuple/List is dangerous. Arrays should be handled as a List and shouldn't be copied (need prototype substitution for that). Tuple should be a `Object.frozen()` array.