### PR TITLE
Add the deadsnakes repository for supporting CPython 3.12 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ jobs:
         chrome: "stable"
         firefox: "latest"
         apt:
+          sources:
+            - sourceline: 'ppa:deadsnakes/ppa'
           packages:
             - libnss3
             - python3.12


### PR DESCRIPTION
One of your recent commits caused the Travis CI build process to fail. The current release of Ubuntu LTS only supports Python 3.10.