### PR TITLE
Improve named arguments parsing when no **kwargs parameters (x1.11 speed)

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -1829,9 +1829,15 @@ function generate_args0(...args) {
 
 function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, hasVargars, hasNamedOnly, namedOnlyDefaults, hasKWargs) {
 
+	console.log('!!!!!!!');
+
     let fct =
 //`function args0_NEW(fct, args) {
 `
+	console.log('!!!');
+	console.log(fct.name, fct);
+	console.log(${[hasPosOnly, posOnlyDefaults, hasPos, posDefaults, hasVargars, hasNamedOnly, namedOnlyDefaults, hasKWargs]});
+
     const LAST_ARGS = args[args.length-1];
     const HAS_KW = LAST_ARGS !== undefined && LAST_ARGS !== null && LAST_ARGS.$kw !== undefined;
 
@@ -1854,6 +1860,7 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     	    ++nb_named_args;
     	    
     	var nb_named_args_orig = nb_named_args;
+    	console.log("result_replaced_by_argsnames");
 `;
     }
 
@@ -1920,6 +1927,18 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
         fct +=
 `
     if( ARGS_POS_COUNT > ${PARAMS_POS_COUNT} ) {
+`
+
+	if( ! hasKWargs && (hasPos || hasNamedOnly) )
+	    fct += `
+	if( HAS_KW ) {
+		
+	    console.log("B");
+	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+	   }
+`;
+
+	fct += `   
         $B.args0_old(fct, args);
         throw new Error('Too much positional arguments given (args0 should have raised an error) !');
     }
@@ -1941,6 +1960,7 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     if( HAS_KW === true ) {
 
         for(let argname in ARGS_NAMED[0] ) {
+        	console.log('error here', fct, args, '!');
             $B.args0_old(fct, args);
             throw new Error('No named arguments expected !!!');
         }
@@ -1948,7 +1968,9 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
         for(let id = 1; id < ARGS_NAMED.length; ++id ) {
 
             const kargs = ARGS_NAMED[id];
-            for(let argname of $B.make_js_iterator( $B.$getattr(kargs.__class__, "keys")(kargs) ) ) { //TODO: not optimal
+            for(let argname of $B.make_js_iterator( $B.$getattr(kargs.__class__, "keys")(kargs) ) ) { //TODO: not optimal`
+
+	fct += `
                 $B.args0_old(fct, args);
                 throw new Error('No named arguments expected !!!');
             }
@@ -1966,7 +1988,18 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
         if( posOnlyDefaults !== DEFAULTS.ALL && posDefaults !== DEFAULTS.ALL ) {
 
             fct += `
-        if( offset < ${PARAMS_POS_DEFAULTS_OFFSET} ) {
+        if( offset < ${PARAMS_POS_DEFAULTS_OFFSET} ) {`
+
+	    if( ! hasKWargs && (hasPos || hasNamedOnly) )
+	        fct += `
+	    if( HAS_KW ) {
+	    
+	    console.log("D");
+	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+	    }
+`;
+
+	fct += `
             $B.args0_old(fct, args);
             throw new Error('Not enough positional arguments given (args0 should have raised an error) !');
         }
@@ -1988,7 +2021,17 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     }
 
     if( hasNamedOnly && namedOnlyDefaults !== DEFAULTS.ALL) {
-        fct += `
+
+	if( ! hasKWargs )
+	    fct += `
+	if( HAS_KW ) {
+	
+	    console.log("E");
+	ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+	}
+`;
+
+	fct += `  
         $B.args0_old(fct, args);
         throw new Error('Named argument expected (args0 should have raised an error) !');
 `
@@ -2002,6 +2045,7 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     }
 
     fct += `
+    	console.log('ok');
         return result;
 `
 
@@ -2034,14 +2078,31 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
         `;
         if( posOnlyDefaults !== DEFAULTS.SOME) {
             fct += `
-        if( offset < ${PARAMS_POS_DEFAULTS_OFFSET} ) {
+        if( offset < ${PARAMS_POS_DEFAULTS_OFFSET} ) {`
+
+	if( ! hasKWargs )
+	    fct += `
+	    
+	    console.log("F");
+	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+`;
+
+	    fct += `
             $B.args0_old(fct, args);
             throw new Error('Not enough positional parameters given (args0 should have raised an error) !');
         }
 `
         }
         if( posOnlyDefaults === DEFAULTS.NONE) {
-            fct += `
+ 
+    	    if( ! hasKWargs )
+	        fct += `
+	        
+	    console.log("G");
+	ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+`;
+
+	fct += `  
         $B.args0_old(fct, args);
         throw new Error('Not enough positional parameters given (args0 should have raised an error) !');
 `;
@@ -2112,7 +2173,16 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
 
         for(let argname of $B.make_js_iterator($B.$getattr(kargs.__class__, "keys")(kargs)) ) {
 
-            if( typeof argname !== "string") {
+            if( typeof argname !== "string") {`
+
+	if( ! hasKWargs )
+	    fct += `
+	    
+	    console.log("H");
+	        ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+`;
+
+	fct += `
                 $B.args0_old(fct, args);
                 throw new Error('Non string key passed in **kargs');
             }
@@ -2164,7 +2234,17 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
         const key = PARAMS_NAMES[ioffset];
         if( key in result ) // maybe could be speed up using "!(key in result)"
             continue;
+`
 
+	if( ! hasKWargs && (hasPos || hasNamedOnly) )
+	    fct += `
+	    
+	    console.log("I");
+	if( HAS_KW )
+        	ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+`;
+
+	fct += `
         $B.args0_old(fct, args);
         throw new Error('Missing a named arguments (args0 should have raised an error) !');
     }
@@ -2196,16 +2276,32 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
         if( namedOnlyDefaults === DEFAULTS.SOME) {
             fct += `
             if( ! kwargs_defaults.has(key) ) {
-                $B.args0_old(fct, args);
+            `
 
+	    if( ! hasKWargs )
+	        fct += `
+	        
+	    console.log("J");
+	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+`;
+
+	    fct += `  
+                $B.args0_old(fct, args);
                 throw new Error('Missing a named arguments (args0 should have raised an error) !');
             }
 `
         }
         if( namedOnlyDefaults === DEFAULTS.NONE ) {
-            fct += `
-            $B.args0_old(fct, args);
 
+            if( ! hasKWargs )
+	        fct += `
+	        
+	    console.log("K");
+	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig))
+`;
+
+	fct += `  
+            $B.args0_old(fct, args);
             throw new Error('Missing a named arguments (args0 should have raised an error) !');
 `
         }
@@ -2230,6 +2326,7 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
 
 	if( ! hasKWargs ) {
 	    fct += `
+	    console.log("A");
 	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig));
 	        
 	    console.log(args, nb_named_args_orig, fct);
@@ -2256,7 +2353,9 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     }
 
     fct += `
-    return result
+    
+   	console.log('ok');
+	return result
     `;
 
     //fct += `}`;

--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -1852,6 +1852,8 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     	var nb_named_args = 0;
     	for(let _ in result)
     	    ++nb_named_args;
+    	    
+    	var nb_named_args_orig = nb_named_args;
 `;
     }
 
@@ -2221,17 +2223,31 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
 `;
     }
 
-    if( hasNamedOnly || hasPos )
+    if( hasNamedOnly || hasPos ) {
         fct += `
         if( found + nb_named_args !== PARAMS_NAMES.length - offset) {
+`;
+
+	if( ! hasKWargs ) {
+	    fct += `
+	    ARGS_NAMED[0] = Object.fromEntries(Object.entries(result).slice(0,nb_named_args_orig));
+	        
+	    console.log(args, nb_named_args_orig, fct);
+`;
+	}
+
+	fct += `
+    		console.log("named");
             $B.args0_old(fct, args);
             throw new Error('Inexistant or duplicate named arguments (args0 should have raised an error) !');
         }
 `;
+    }
 
     if( hasKWargs ) {
         fct += `
     if( Object.keys(extra).length !== nb_extra_args ) {
+    	console.log("extra");
         $B.args0_old(fct, args);
         throw new Error('Duplicate name given to **kargs parameter (args0 should have raised an error) !');
     }
@@ -2247,7 +2263,7 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     return fct;
 }
 
-console.log("pos", generate_args0_str(false, DEFAULTS.NONE, true, DEFAULTS.NONE, false, false, DEFAULTS.NONE, false) );
+console.log("pos", generate_args0_str(false, 0, true, 0, false, true, 0, false) );
 
 const USE_PERSO_ARGS0_EVERYWHERE = true;
 

--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -1838,13 +1838,27 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     let ARGS_POS_COUNT        = args.length;
     let ARGS_NAMED            = null;
 
+    let result = {};
+    
     if( HAS_KW ) {
         --ARGS_POS_COUNT;
         ARGS_NAMED = LAST_ARGS.$kw;
+`;
+
+    if( (hasPos || hasNamedOnly) && ! hasKWargs ) {
+    	fct += `
+    	//result = Object.assign({}, ARGS_NAMED[0]); // temporary due to the use of args0_old for error message.
+    	result = ARGS_NAMED[0];
+    	var nb_named_args = 0;
+    	for(let _ in result)
+    	    ++nb_named_args;
+`;
+    }
+
+    fct += `
     }
 
 
-    const result = {};
 
     // using const should enable the browser to perform some optimisation.
     const $INFOS = fct.$infos;
@@ -2056,9 +2070,8 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     const HAS_PARAMS = fct.$hasParams;
 `;
         }
-    }
-
-    fct += `
+        
+        fct += `
 
     let nb_named_args = 0;
 
@@ -2068,21 +2081,13 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     for(let argname in kargs) {
         `;
 
-        if( ! hasKWargs ) {
-            fct += `
-        result[ argname ] = kargs[argname];
-        ++nb_named_args;
-`;
-        }
-
-        if( hasKWargs ) {
-            if( ! hasNamedOnly && ! hasPos ) {
-                fct += `
+        if( ! hasNamedOnly && ! hasPos ) {
+           fct += `
         extra[ argname ] = kargs[argname];
         ++nb_extra_args;
 `
-            } else {
-                fct += `
+        } else {
+           fct += `
         if( HAS_PARAMS.has(argname) ) {
             result[ argname ] = kargs[argname];
             ++nb_named_args;
@@ -2091,11 +2096,13 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
             ++nb_extra_args;
         }
 `
-            }
         }
-
-        fct += `
+        
+        fct += `}`;
+        
     }
+
+    fct += `
 
     for(let id = 1; id < ARGS_NAMED.length; ++id ) {
 
@@ -2240,7 +2247,7 @@ function generate_args0_str(hasPosOnly, posOnlyDefaults, hasPos, posDefaults, ha
     return fct;
 }
 
-//console.log("pos", generate_args0_str(false, DEFAULTS.NONE, false, DEFAULTS.NONE, false, true, DEFAULTS.NONE, true) );
+console.log("pos", generate_args0_str(false, DEFAULTS.NONE, true, DEFAULTS.NONE, false, false, DEFAULTS.NONE, false) );
 
 const USE_PERSO_ARGS0_EVERYWHERE = true;
 


### PR DESCRIPTION
Hi,


Improve a little (1.11x speed) parsing of named arguments when the function has no `**kwargs` parameters.

You'll see there is an issue in the error message generation due to the fact I use the old parsing method to generate the error message (by doing an assign -commented in the code- it removes the error).

I'll have to generate the error message myself.


EDIT: performances is now similar to positional arguments parsing.


Cordially,