### PR TITLE
Fix errors and set `pre` HTML tag style to monospace, not default browser font (Times New Roman serif font)

### DIFF
--- a/www/brython.css
+++ b/www/brython.css
@@ -211,7 +211,7 @@ select.language {
     border-color:#888;
     border-radius: 10px;
     width:auto;
-    font-family: "Consolas";
+    font-family: "Consolas", monospace;
 }
 
 .pycode-in-html{
@@ -251,7 +251,7 @@ li {
 }
 
 pre{
-    font-family: Consolas;
+    font-family: Consolas, monospace;
 }
 pre.marked {
   color:var(--dark-3);
@@ -292,7 +292,7 @@ span.html-attrs{
 
 code {
   color:var(--dark-3);
-  font-family: Consolas;
+  font-family: Consolas, monospace;
 }
 
 code.file{

--- a/www/doc/doc_brython.css
+++ b/www/doc/doc_brython.css
@@ -146,7 +146,7 @@ select.language {
     border-color:#888;
     border-radius: 10px;
     width:auto;
-    font-family: "Consolas";
+    font-family: "Consolas", monospace;
 }
 
 .xml{
@@ -176,7 +176,7 @@ li {
 }
 
 pre{
-    font-family: Consolas;
+    font-family: Consolas, monospace;
 }
 pre.marked {
   color:var(--header-color);
@@ -200,7 +200,7 @@ span.python-builtin{
 
 code {
   color:var(--special-text-color);
-  font-family: Consolas;
+  font-family: Consolas, monospace;
 }
 
 em {

--- a/www/tests/console.css
+++ b/www/tests/console.css
@@ -41,7 +41,7 @@ textarea {
     width:100%;
     height:100%;
     font-size: 12px;
-    font-family: Consolas,"Courier new"
+    font-family: Consolas,"Courier New", monospace;
     float:none;
     background-color:var(--dark-3);
     color:var(--clear-1);


### PR DESCRIPTION
I fix some CSS errors and set the `<pre>` HTML tag style to monospaced font, not default browser font (like Times New Roman serif font in [Brython interactive console at Brython website](https://brython.info/tests/console.html))