### PR TITLE
Soften URL regex

### DIFF
--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -101,7 +101,7 @@ if(mo){
 }
 
 $B.strip_host = function(url){
-    var parts_re = new RegExp('(.*?)://(.*?)/(.*)'),
+    var parts_re = new RegExp('(.*?)://(.*?)[/#]?(.*)'),
         mo = parts_re.exec(url)
     if(mo){
         return mo[3]


### PR DESCRIPTION
The regular expression from the `strip_host` function may cause errors when running Brython in embedded browsers.

For example, here is an error that I get with a [tauri](https://tauri.app) app:
```
Error: not a url: tauri://localhost#__main__1093904193440517
	(anonymous function) (brython.js:49)
	run_scripts (brython.js:944:139)
	injectPythonScript (brython.js:869)
	(anonymous function) (brython.js:883:154)
```

This pull request aim to fix that.

I added a question mark because sometimes the URL is just `tauri://localhost`, which also makes the function throw an error.