### PR TITLE
Introducing Brython Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Curious about [how Brython works](https://github.com/brython-dev/brython/wiki/Ho
 A [tutorial](https://github.com/brython-dev/brython/wiki/Writing-an-Android-application)
 explains how to build Android applications with Brython.
 
+You can also [Ask Brython Guru](https://gurubase.io/g/brython), it is a Brython-focused AI to answer your questions.
+
 Community (questions, feedback, issues, new features, ...)
 ==========================================================
 You can subscribe and post to the


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Brython Guru](https://gurubase.io/g/brython) to Gurubase. Brython Guru uses the data from this repo and data from the [docs](https://www.brython.info/static_doc/3.13/en/intro.html) to answer questions by leveraging the LLM.

In this PR, I showcased the "Brython Guru", which highlights that Brython now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Brython Guru in Gurubase, just let me know that's totally fine.