### PR TITLE
Fixes #2569: don't use time_ns

### DIFF
--- a/www/src/Lib/logging/__init__.py
+++ b/www/src/Lib/logging/__init__.py
@@ -56,7 +56,7 @@ __date__    = "07 February 2010"
 #
 #_startTime is used as the base when calculating the relative time of events
 #
-_startTime = time.time_ns()
+_startTime = time.time()
 
 #
 #raiseExceptions is used to see if exceptions during handling should be
@@ -300,7 +300,7 @@ class LogRecord(object):
         """
         Initialize a logging record with interesting information.
         """
-        ct = time.time_ns()
+        ct = time.time()
         self.name = name
         self.msg = msg
         #
@@ -339,14 +339,9 @@ class LogRecord(object):
         self.stack_info = sinfo
         self.lineno = lineno
         self.funcName = func
-        self.created = ct / 1e9  # ns to float seconds
-
-        # Get the number of whole milliseconds (0-999) in the fractional part of seconds.
-        # Eg: 1_677_903_920_999_998_503 ns --> 999_998_503 ns--> 999 ms
-        # Convert to float by adding 0.0 for historical reasons. See gh-89047
-        self.msecs = (ct % 1_000_000_000) // 1_000_000 + 0.0
-
-        self.relativeCreated = (ct - _startTime) / 1e6
+        self.created = ct
+        self.msecs = int((ct - int(ct)) * 1000) + 0.0  # see gh-89047
+        self.relativeCreated = (self.created - _startTime) * 1000
         if logThreads:
             self.thread = threading.get_ident()
             self.threadName = threading.current_thread().name
@@ -577,7 +572,7 @@ class Formatter(object):
     %(lineno)d          Source line number where the logging call was issued
                         (if available)
     %(funcName)s        Function name
-    %(created)f         Time when the LogRecord was created (time.time_ns() / 1e9
+    %(created)f         Time when the LogRecord was created (time.time() 
                         return value)
     %(asctime)s         Textual time when the LogRecord was created
     %(msecs)d           Millisecond portion of the creation time


### PR DESCRIPTION
Browsers don't seem to allow access to the nanoseconds. This basically just reverts [1316692](https://github.com/python/cpython/commit/1316692e8c7c1e1f3b6639e51804f9db5ed892ea).

I tried running the test suite but failed (I just got a `403: Forbidden`).