### PR TITLE
Fix `make_package` ignoring `--src-dir`

### DIFF
--- a/setup/brython/__main__.py
+++ b/setup/brython/__main__.py
@@ -54,7 +54,7 @@ def main():
 
     make_package_parser.add_argument('package_name',
         help="name used to import this package. as in (`import {package_name}`)")
-    make_package_parser.add_argument('--src-dir', metavar='SOURCE_DIR',
+    make_package_parser.add_argument('--src-dir', metavar='SOURCE_DIR', default=os.getcwd(),
         help="package source dir (defaults to current dir)")
     make_package_parser.add_argument('--exclude-dirs', nargs='+', metavar='EXCLUDE_DIR',
         help="directories under src-dir to exclude")
@@ -259,7 +259,7 @@ def main():
 
         case 'make_package':
             package_name = args.package_name
-            package_path = os.getcwd()
+            package_path = args.src_dir
             exclude_dirs = args.exclude_dirs
             output_path = args.output_path
             from . import make_package


### PR DESCRIPTION
Very simple oversight I mentioned as part of a different issue in https://github.com/brython-dev/brython/issues/2567#issuecomment-2835174777.

With this PR, `make_package` respects the passed `--src-dir` directory. The default `--output-path` remains unchanged and is still relative to the source directory - personally I think it should be relative to the **current** directory, as then that'd accommodate for directory structure like this:
```
assets\
   brython\
      my_modules.py
   js\
      my_modules.brython.js
```

without having to resort to a strange relative output path in the form of `..\js\my_modules.brython.js`.

I am not going to make this call on my own though. @PierreQuentel if you think this behaviour makes more sense than the current one, I'll update the PR modifying `--output-path` with its help and docs.