### PR TITLE
fix text attribute getter

### DIFF
--- a/www/src/libs/_ajax.js
+++ b/www/src/libs/_ajax.js
@@ -151,7 +151,7 @@ ajax.__getattribute__ = function(self, attr){
             return ajax[attr].call(null, self, ...arguments)
         }
     }else if(attr == "text"){
-        return _read(self)
+        return self.js.responseText
     }else if(attr == "json"){
         if(self.js.responseType == "json"){
             return _read(self)

--- a/www/src/libs/_ajax.js
+++ b/www/src/libs/_ajax.js
@@ -151,6 +151,9 @@ ajax.__getattribute__ = function(self, attr){
             return ajax[attr].call(null, self, ...arguments)
         }
     }else if(attr == "text"){
+        if(self.mode == "binary"){
+            return _read(self)
+        }
         return self.js.responseText
     }else if(attr == "json"){
         if(self.js.responseType == "json"){


### PR DESCRIPTION
Currently the `text` attribute getter calls `_read()`, which returns an object whose type is dependent on the request mode. This is not the behaviour specified in the [docs](https://github.com/CyrilSLi/brython/blob/master/www/doc/en/browser.ajax.md?plain=1#L81-L84`).

Example code (tested on version 3.13.1):
```python
from browser import ajax, window
ajax.get("https://jsonplaceholder.typicode.com/posts/1", mode="json", oncomplete=lambda res: window.console.log(res.text))
```
logs a JSON object to the console.