### PR TITLE
Add JS convenient function importPythonModule

### DIFF
--- a/www/src/brython_builtins.js
+++ b/www/src/brython_builtins.js
@@ -563,4 +563,8 @@ $B.runPythonSource = function(src, options){
     return $B.imported[script_id]
 }
 
+$B.importPythonModule = function(name, options){
+    return $B.runPythonSource('import ' + name, options)
+}
+
 })(__BRYTHON__);


### PR DESCRIPTION
In the documentation:
```JavaScript
var src = "import some_module"
__BRYTHON__.runPythonSource(src, {pythonpath: 'my_modules', debug: 2})
```
has now a clean API:
```JavaScript
__BRYTHON__.importPythonModule(some_module, {pythonpath: 'my_modules', debug: 2})
```