### PR TITLE
abspath() instead getcwd()

### DIFF
--- a/scripts/make_dist.py
+++ b/scripts/make_dist.py
@@ -22,10 +22,7 @@ if implementation[3] == 'rc':
 vname2 = '.'.join(str(x) for x in implementation[:2])
 vname1 = str(implementation[0])
 
-# path of parent directory
-pdir = os.path.dirname(os.getcwd())
-
-script_dir = os.path.dirname(os.getcwd())
+script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def abs_path(path):
     return os.path.join(script_dir, 'www', 'src', path)
@@ -133,7 +130,7 @@ def run():
         make_VFS = None
         sys.exit()
 
-    make_VFS.process(os.path.join(pdir, 'www', 'src', 'brython_stdlib.js'))
+    make_VFS.process(abs_path('brython_stdlib.js'))
 
 
 if __name__ == "__main__":

--- a/scripts/make_stdlib_static.py
+++ b/scripts/make_stdlib_static.py
@@ -5,7 +5,7 @@ import os
 
 import git
 
-libfolder = os.path.join(os.path.dirname(os.getcwd()), 'www', 'src')
+libfolder = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'www', 'src')
 simple_javascript_template_string = """;"use strict";\n(function($B){\n
 $B.stdlib = {}
 """

--- a/scripts/make_version_info.py
+++ b/scripts/make_version_info.py
@@ -4,7 +4,7 @@ import time
 
 from version import version, implementation
 
-script_dir = os.path.dirname(os.getcwd())
+script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 abs_path = lambda _pth: os.path.join(script_dir, 'www',
     'src', _pth)
 


### PR DESCRIPTION
Using `os.path.abspath(__file__)` instead  `os.getcwd()`, both
```console
cd scripts
python3.13 make_dist.py
```
and
```console
python3.13 scripts/make_dist.py
```
works

Probably all others `os.getcwd()` should be fixed too.