### PR TITLE
Fix random import error when running scripts

### DIFF
--- a/www/src/Lib/importlib/util.py
+++ b/www/src/Lib/importlib/util.py
@@ -127,7 +127,7 @@ def _module_to_load(name):
         module = type(sys)(name)
         # This must be done before putting the module in sys.modules
         # (otherwise an optimization shortcut in import.c becomes wrong)
-        module.__initializing__ = True
+        module.__initialized__ = False
         sys.modules[name] = module
     try:
         yield module
@@ -138,7 +138,7 @@ def _module_to_load(name):
             except KeyError:
                 pass
     finally:
-        module.__initializing__ = False
+        module.__initialized__ = True
 
 
 def set_package(fxn):

--- a/www/src/Lib/pydoc.py
+++ b/www/src/Lib/pydoc.py
@@ -276,7 +276,6 @@ _future_feature_names = set(__future__.all_feature_names)
 def visiblename(name, all=None, obj=None):
     """Decide whether to show documentation on a variable."""
     # Certain special names are redundant or internal.
-    # XXX Remove __initializing__?
     if name in {'__author__', '__builtins__', '__cached__', '__credits__',
                 '__date__', '__doc__', '__file__', '__spec__',
                 '__loader__', '__module__', '__name__', '__package__',

--- a/www/src/Lib/test/test_pkg.py
+++ b/www/src/Lib/test/test_pkg.py
@@ -22,8 +22,8 @@ def cleanout(root):
 def fixdir(lst):
     if "__builtins__" in lst:
         lst.remove("__builtins__")
-    if "__initializing__" in lst:
-        lst.remove("__initializing__")
+    if "__initialized__" in lst:
+        lst.remove("__initialized__")
     return lst
 
 

--- a/www/src/py_import.js
+++ b/www/src/py_import.js
@@ -332,7 +332,7 @@ function run_py(module_contents, path, module, compiled) {
         for(let attr in mod){
             module[attr] = mod[attr]
         }
-        module.__initializing__ = false
+        module.__initialized__ = true
         // $B.imported[mod.__name__] must be the module object, so that
         // setting attributes in a program affects the module namespace
         // See issue #7

--- a/www/src/py_import.js
+++ b/www/src/py_import.js
@@ -509,7 +509,7 @@ VFSLoader.exec_module = function(self, modobj){
                 elts.pop()
                 mod.__package__ = elts.join(".")
             }
-            mod.__file__ = mod.__path__ = path
+            mod.__file__ = path
             try{
                 var parent_id = parent.replace(/\./g, "_"),
                     prefix = 'locals_'

--- a/www/src/py_import.js
+++ b/www/src/py_import.js
@@ -509,7 +509,7 @@ VFSLoader.exec_module = function(self, modobj){
                 elts.pop()
                 mod.__package__ = elts.join(".")
             }
-            mod.__file__ = path
+            mod.__file__ = mod.__path__ = path
             try{
                 var parent_id = parent.replace(/\./g, "_"),
                     prefix = 'locals_'

--- a/www/src/py_import.js
+++ b/www/src/py_import.js
@@ -1093,11 +1093,15 @@ $B.$__import__ = function(mod_name, globals, locals, fromlist){
                 _b_.setattr($B.imported[_parent_name], parsed_name[i],
                     $B.imported[_mod_name])
             }
-            // [Import spec] If __path__ can not be accessed an ImportError is raised
+            // Note: Brython doesn't follow Python convention and every module should have __file__
+            //       __path__ should be redundant but kept in as precaution
+            // [Import spec] Module check
             if(i < len){
-                try{
-                    __path__ = $B.$getattr($B.imported[_mod_name], "__path__")
-                }catch(e){
+                if (
+                    $B.$getattr($B.imported[_mod_name], "__file__", 
+                    $B.$getattr($B.imported[_mod_name], "__path__", $B.None))
+                    === $B.None
+                ) {
                     // If this is the last but one part, and the last part is
                     // an attribute of module, and this attribute is a module,
                     // return it. This is the case for os.path for instance


### PR DESCRIPTION
Addresses #2609

The underlying issue seemed to be some inconsistency with a magic `__initialized__` and `__initializing__` variable. I'm under the impression these are both Brython internals.

It looks like Brython always assigns `__file__` but there might be a case where both `__file__` and `__path__` are missing. It looked like the intent of the code was to determine whether you were attempting to import from a non-module. If Brython supports namespace modules, it would be a case where `__file__` doesn't exist. ChatGPT suggested that this code would break for built-in modules, but we seem to assign a `__file__` for them.