### PR TITLE
Fix console page

### DIFF
--- a/www/console.html
+++ b/www/console.html
@@ -26,6 +26,7 @@
     <script type="text/javascript" src="/src/py_utils.js"></script>
     <script type="text/javascript" src="/src/py_object.js"></script>
     <script type="text/javascript" src="/src/py_type.js"></script>
+    <script type="text/javascript" src="/src/py_functions.js"></script>
     <script type="text/javascript" src="/src/py_builtin_functions.js"></script>
     <script type="text/javascript" src="/src/py_sort.js"></script>
     <script type="text/javascript" src="/src/py_exceptions.js"></script>


### PR DESCRIPTION
Right now, opening console page shows two errors in DevTools:
```
Uncaught TypeError: can't access property "__getattribute__", $B.function is undefined
    <anonymous> https://brython.info/src/py_builtin_functions.js:3403
    <anonymous> https://brython.info/src/py_builtin_functions.js:3463

Uncaught TypeError: can't access property "__getattribute__", $B.function is undefined
    <anonymous> https://brython.info/src/builtin_modules.js:1295
    <anonymous> https://brython.info/src/builtin_modules.js:1507
```
which seem to break console functionality.