### PR TITLE
apply repr() by default when processing debug f-string expressions like f"{x=}"

### DIFF
--- a/www/src/action_helpers.js
+++ b/www/src/action_helpers.js
@@ -373,16 +373,15 @@ $B._PyPegen.interpolation = function(p, expression,
 $B._PyPegen.formatted_value = function(p,
         expression, debug,  conversion, format, closing_brace,
         arena){
-    var conversion_val = -1
-    if(conversion){
-        var conversion_expr = conversion.result,
-            first = conversion_expr.id
-        if(first.length > 1 || ! 'sra'.includes(first)){
-            $B.helper_functions.RAISE_SYNTAX_ERROR_KNOWN_LOCATION(conversion_expr,
-                `f-string: invalid conversion character {first}: ` +
+    var conversion_val = _get_interpolation_conversion(p, debug, conversion, format)
+    if(typeof conversion_val == 'string'){
+        // Got a conversion character, validate and convert to charCode
+        if(conversion_val.length > 1 || ! 'sra'.includes(conversion_val)){
+            $B.helper_functions.RAISE_SYNTAX_ERROR_KNOWN_LOCATION(conversion.result,
+                `f-string: invalid conversion character ${conversion_val}: ` +
                 "expected 's', 'r', or 'a'")
         }
-        var conversion_val = first.charCodeAt(0)
+        conversion_val = conversion_val.charCodeAt(0)
     }
     var formatted_value = new $B.ast.FormattedValue(expression,
         conversion_val,

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -3327,3 +3327,7 @@ assert datetime.time(0).strftime('%I') == '12'
 # Finally, report that all tests have passed
 # ==========================================
 print('passed all tests')
+
+# issue 2628
+foo = "bar"
+assert f"{foo=}" == "foo='bar'"


### PR DESCRIPTION
Fixes #2628 