### PR TITLE
Update abstract class error message format to match Python 3.14

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1263,10 +1263,12 @@ $B.$instance_creator = function(klass){
         return function(){
             var ams = Array.from($B.make_js_iterator(klass.__abstractmethods__))
             ams.sort()
-            var msg = (ams.length > 1 ? 's ' : ' ') + ams.join(', ')
+            var quoted_methods = ams.map(m => "'" + m + "'").join(', ')
+            var method_word = ams.length > 1 ? 'methods' : 'method'
             $B.RAISE(_b_.TypeError,
-                "Can't instantiate abstract class interface " +
-                "with abstract method" + msg)
+                "Can't instantiate abstract class " + klass.__name__ +
+                " without an implementation for abstract " + method_word + " " +
+                quoted_methods)
         }
     }
     var metaclass = klass.__class__ || $B.get_class(klass),

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -3331,3 +3331,29 @@ print('passed all tests')
 # issue 2628
 foo = "bar"
 assert f"{foo=}" == "foo='bar'"
+
+# issue 2644 - abstract class instantiation error message format
+class AbstractSingle(metaclass=ABCMeta):
+    @abstractmethod
+    def method1(self):
+        pass
+
+try:
+    AbstractSingle()
+    assert False, "Should have raised TypeError"
+except TypeError as e:
+    assert str(e) == "Can't instantiate abstract class AbstractSingle without an implementation for abstract method 'method1'"
+
+class AbstractMultiple(metaclass=ABCMeta):
+    @abstractmethod
+    def method1(self):
+        pass
+    @abstractmethod
+    def method2(self):
+        pass
+
+try:
+    AbstractMultiple()
+    assert False, "Should have raised TypeError"
+except TypeError as e:
+    assert str(e) == "Can't instantiate abstract class AbstractMultiple without an implementation for abstract methods 'method1', 'method2'"


### PR DESCRIPTION
Update TypeError message when instantiating abstract classes to match Python 3's format: "Can't instantiate abstract class X without an implementation for abstract method(s) 'y', 'z'"

Fixes #2644 

Not sure how valuable the unit test is, feel free to delete it.