### PR TITLE
Fix StringIO missing 'closed' attribute

### DIFF
--- a/www/src/libs/_io_classes.js
+++ b/www/src/libs/_io_classes.js
@@ -113,6 +113,7 @@ StringIO.__init__ = function(){
     $.self.$text = value
     $.self.$text_pos = 0
     $.self.$text_iterator = $.self.$text[Symbol.iterator]()
+    $.self.closed = false
 }
 
 StringIO.__mro__ = [$B._TextIOBase, $B._IOBase, _b_.object]


### PR DESCRIPTION
Fixes #2648 

StringIO.__init__ was not initializing the 'closed' attribute, causing AttributeError when accessing it. BytesIO correctly initializes this. Added `$.self.closed = false` to match BytesIO behavior.

