### PR TITLE
Fix dict.setdefault with non-string keys on string-only dicts

### DIFF
--- a/www/src/py_dict.js
+++ b/www/src/py_dict.js
@@ -1324,10 +1324,15 @@ dict.setdefault = function(){
     _default = _default === undefined ? _b_.None : _default
 
     if(self.$all_str){
-        if(! self.$strings.hasOwnProperty(key)){
-            self.$strings[key] = _default
+        if(typeof key === 'string'){
+            if(! self.$strings.hasOwnProperty(key)){
+                self.$strings[key] = _default
+            }
+            return self.$strings[key]
+        }else{
+            // Non-string key, convert to regular dict
+            convert_all_str(self)
         }
-        return self.$strings[key]
     }
 
     if(self.$jsobj){

--- a/www/tests/issues.py
+++ b/www/tests/issues.py
@@ -3336,6 +3336,17 @@ class EmailChannel:
 
 MagicMock(spec=EmailChannel)
 
+# issue 2650 - WeakKeyDictionary.setdefault() raises JavascriptError
+import weakref
+
+class Foo2650:
+    pass
+
+foo2650 = Foo2650()
+tags2650 = weakref.WeakKeyDictionary()
+tags2650.setdefault(foo2650, 1)
+assert tags2650[foo2650] == 1
+
 # ==========================================
 # Finally, report that all tests have passed
 # ==========================================


### PR DESCRIPTION
Fixes #2650 

When a dict is created with {} literal, Brython optimizes it as string-only. dict.setdefault wasn't checking if the key is a string before using this optimized path, causing "Cannot convert object to primitive value" error when called with non-string keys like weakref.ref objects.

