### PR TITLE
fix JSFunction.tp_getattro — expose .name as __name__/__qualname__

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -1352,6 +1352,16 @@ $B.JSConstructor.tp_call = function(self, ...args){
 $B.JSFunction = $B.make_builtin_class('JavascriptFunction')
 
 $B.JSFunction.tp_getattro = function(self, attr){
+    if(attr === '__name__' || attr === '__qualname__'){
+        // A JS function has a `.name`, not `.__name__`; expose it so
+        // str()/repr() and introspection (e.g. unittest.assertRaises
+        // naming the callable) don't crash with AttributeError on a
+        // bare JS function.
+        var jsf = self[JSOBJ] || self
+        if(jsf && typeof jsf.name === 'string' && jsf.name){
+            return jsf.name
+        }
+    }
     if(self[JSOBJ] && self[JSOBJ][attr] !== undefined){
         return jsobj2pyobj(self[JSOBJ][attr], self[JSOBJ])
     }


### PR DESCRIPTION
```Python
>>> from browser import window
>>> set_timeout = window.setTimeout       # bare JS function via DOM
>>> set_timeout.__name__                  # before
AttributeError: 'JavascriptFunction' object has no attribute '__name__'
>>> set_timeout.__name__                  # after
'setTimeout'
```
