### PR TITLE
fix bound-method — propagate $function_infos through .bind() in tp_descr_get

### DIFF
--- a/www/src/descriptors.js
+++ b/www/src/descriptors.js
@@ -263,6 +263,11 @@ $B.method_descriptor.tp_descr_get = function(self, obj, klass){
     var f = self.method.bind(null, obj)
     f.ob_type = $B.builtin_method
     f.$infos = self.$infos
+    // .bind() drops the target's own properties; carry $function_infos
+    // through so builtin_function_or_method's __name__/__qualname__/repr
+    // getters (which read self.$function_infos[...] unguarded) work on
+    // the bound method, as they do on the unbound descriptor's method.
+    f.$function_infos = self.method.$function_infos
     f.ml = {ml_name: self.d_name}
     f.m_self = obj
     return f


### PR DESCRIPTION
```Python
# Any bound method of a C / builtin type
>>> arr.append.__name__          # before
JavascriptError: can't access property 1, self.$function_infos is undefined
>>> arr.append.__name__          # after
'append'
```