### PR TITLE
Fix false syntax errors for OR patterns

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -2216,7 +2216,7 @@ $B.ast.For.prototype.to_js = function(scopes){
     scopes.push(new_scope)
 
     var inum = add_to_positions(scopes, this.iter)
-
+    
     if(this instanceof $B.ast.AsyncFor){
         js += prefix + `var no_break_${id} = true,\n` +
               prefix + tab + tab + `iter_${id} = ${iter},\n` +
@@ -3233,31 +3233,31 @@ function irrefutable_error(pattern){
 }
 
 function pattern_bindings(pattern){
-    var bindings = []
+    let bindings = []
     switch(pattern.constructor){
+        case $B.ast.MatchSequence:
+        case $B.ast.MatchMapping:
+            if(pattern.rest){
+                bindings.push(pattern.rest)
+            }
+        case $B.ast.MatchClass:
+            for(let p of [...pattern.patterns, ...(pattern?.kwd_patterns ?? [])]){
+                bindings = bindings.concat(pattern_bindings(p))
+            }
+            break
+        case $B.ast.MatchStar:
         case $B.ast.MatchAs:
             if(pattern.name){
                 bindings.push(pattern.name)
             }
             break
-        case $B.ast.MatchSequence:
-            for(var p of pattern.patterns){
-                bindings = bindings.concat(pattern_bindings(p))
-            }
-            break
         case $B.ast.MatchOr:
             bindings = pattern_bindings(pattern.patterns[0])
-            var err_msg = 'alternative patterns bind different names'
+            let err_msg = 'alternative patterns bind different names'
             for(var i = 1; i < pattern.patterns.length; i++){
-                var _bindings = pattern_bindings(pattern.patterns[i])
-                if(_bindings.length != bindings.length){
+                let _bindings = pattern_bindings(pattern.patterns[i])
+                if(_bindings.length !== bindings.length || !bindings.every((_, j) => bindings[j] === _bindings[j])){
                     compiler_error(pattern, err_msg)
-                }else{
-                    for(var j = 0; j < bindings.length; j++){
-                        if(bindings[j] != _bindings[j]){
-                            compiler_error(pattern, err_msg)
-                        }
-                    }
                 }
             }
             break


### PR DESCRIPTION
The `pattern_bindings` function previously ignored star subpatterns (extended unpacking in sequence patterns), mapping patterns, and class patterns. As a result, OR patterns containing sequence patterns with star subpatterns (`[x, y, *rest]`), mapping patterns (`{"bandwidth": b, "latency": l}`), or class patterns (`KeyPress(key_name="Q")`) would throw false syntax errors, since the name bindings of some subpatterns were not counted at all. This fixes that by ensuring `pattern_bindings` actually returns a complete array of all bound names.

Also, just curious, why not use semicolons, `const`, or iteration with `forEach` and `map`? Why use `var` everywhere and not put spaces before opening curly braces and after control flow keywords? This coding style disagrees with me.