### PR TITLE
Fix float.fromhex() of a negative value (float.__neg__ undefined)

### DIFF
--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -1189,7 +1189,7 @@ float_funcs.fromhex = function(klass, s) {
           throw parse_error()
       }
       if (negate) {
-          x = float.__neg__(x)
+          x = float.nb_negative(x)
       }
       return klass === _b_.float ? x : $B.$call(klass, x)
     }


### PR DESCRIPTION
```Python
>>> float.fromhex('-0x1p0')
JavascriptError: float.__neg__ is not a function  # before
>>> float.fromhex('-0x1p0')
-1.0                                              # after
```
