### PR TITLE
jsobj2pyobj: don't re-wrap an already-Python callable

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -210,6 +210,13 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this) {
     }
 
     if (typeof jsobj === "function") {
+        // A function that already carries a Brython type (ob_type) is already
+        // a Python callable (e.g. a builtin_function_or_method such as `iter`);
+        // return it unchanged instead of building a fresh JavascriptFunction
+        // wrapper, which would lose its identity, __name__ and __module__.
+        if (jsobj.ob_type !== undefined) {
+            return jsobj
+        }
         // transform Python arguments to equivalent JS arguments
         _this = _this === undefined ? null : _this
 


### PR DESCRIPTION
```Python
>>> from browser import window
>>> window.Array(iter)[0] is iter
False   # before
>>> window.Array(iter)[0] is iter
True    # after
```