### PR TITLE
math: isinf coerces via __float__ like isnan/isfinite; fsum handles special values (-inf + inf raises ValueError)

### DIFF
--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -1410,12 +1410,24 @@ function fsum(x) {
     */
     var partials = [],
         res = new Number(),
+        inf_sum = 0,
+        special_sum = 0,
         _it = _b_.iter(x)
     while (true) {
         try {
             var x = _b_.next(_it),
                 i = 0
             x = float_check(x)
+            if (! isFinite(x)) {
+                // Special values: track infinities and nans separately, as
+                // CPython's math_fsum does, so that inf + inf returns inf,
+                // nan propagates, and -inf + inf raises ValueError below.
+                if (x === Infinity || x === -Infinity) {
+                    inf_sum += x
+                }
+                special_sum += x
+                continue
+            }
             for (var j = 0, len = partials.length; j < len; j++) {
                 var y = float_check(partials[j])
                 if (Math.abs(x) < Math.abs(y)) {
@@ -1436,6 +1448,12 @@ function fsum(x) {
             if ($B.$isinstance(err, _b_.StopIteration)) {break}
             throw err
         }
+    }
+    if (special_sum !== 0) {
+        if (isNaN(inf_sum)) {
+            $B.RAISE(_b_.ValueError, '-inf + inf in fsum')
+        }
+        return $B.fast_float(special_sum)
     }
     var res = 0
     for (var i = 0; i < partials.length; i++) {
@@ -1760,7 +1778,13 @@ function isfinite(x) {
 function isinf(x) {
     $B.check_nb_args('isinf', 1, arguments)
     $B.check_no_kw('isinf', x)
-    return _b_.float.$funcs.isinf(x)
+    if (_b_.float.$funcs.isinf(x)) {
+        return true
+    }
+    // Like isnan/isfinite, coerce through float_check so any __float__-able
+    // argument (e.g. Decimal('inf')) is handled, as in CPython.
+    var y = float_check(x)
+    return y === Infinity || y === -Infinity
 }
 
 function isnan(x) {


### PR DESCRIPTION
```Python
>>> math.isinf(Decimal('inf'))
False  # before
>>> math.isinf(Decimal('inf'))
True   # after
>>> math.fsum([float('inf'), float('-inf')])
nan                             # before
>>> math.fsum([float('inf'), float('-inf')])
ValueError: -inf + inf in fsum  # after
```