### PR TITLE
object.__reduce_ex__: honor a Python-level __reduce__ override (the guard only recognized method_descriptor overrides)

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -613,9 +613,12 @@ object_funcs.__reduce_ex__ = function(self, protocol) {
     var klass = $B.get_class(self)
     var reduce = $B.$getattr(klass, '__reduce__')
 
-    if(reduce !== object.tp_funcs.__reduce__ &&
-            ((reduce.ob_type === $B.method_descriptor) &&
-             (reduce.method !== object.tp_funcs.__reduce__))){
+    // Honor ANY non-default override: a Python-level __reduce__ is a plain
+    // function (not a method_descriptor) and was silently ignored.
+    var reduce_is_default = (reduce === object.tp_funcs.__reduce__) ||
+            (reduce.ob_type === $B.method_descriptor &&
+             reduce.method === object.tp_funcs.__reduce__)
+    if(! reduce_is_default){
         return $B.$call(reduce, self)
     }
     if ($B.imported.copyreg === undefined) {


### PR DESCRIPTION
```Python
>>> class C:
...     def __reduce__(self): return (C, ('marker',))
>>> C().__reduce_ex__(2)
(<function __newobj__>, (<class 'C'>,), None, None, None)  # before
>>> C().__reduce_ex__(2)
(<class 'C'>, ('marker',))                                 # after
```