### PR TITLE
open(): resolve os.PathLike arguments via __fspath__

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -976,6 +976,15 @@ function _io_open_impl(file, mode, buffering, encoding, errors, newline,
     path_or_fd = file
 
     if (! $B.is_str(path_or_fd)) {
+        // os.PathLike support: CPython's open() accepts any object with
+        // __fspath__ (pathlib.Path, DirEntry, ...).
+        var fspath = $B.$getattr(file, '__fspath__', null)
+        if (fspath !== null) {
+            path_or_fd = $B.$call(fspath)
+        }
+    }
+
+    if (! $B.is_str(path_or_fd)) {
         $B.RAISE(_b_.TypeError, `invalid file: ${file}`)
     }
 


### PR DESCRIPTION
```Python
>>> open(pathlib.Path('data.txt'))
TypeError: invalid file: [object Object]  # before
>>> open(pathlib.Path('data.txt'))
<_io.TextIOWrapper name='data.txt'>       # after
```