### PR TITLE
float binary ops accept only int/float — no __float__ coercion (Decimal(5) + 2.2 computed 7.2 instead of raising TypeError)

### DIFF
--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -564,12 +564,10 @@ function conv_float(...objs) {
             x = obj
         } else if ($B.is_int(obj)) {
             x = _b_.int.nb_float(obj)
-        } else {
-            var float_method = $B.$getattr($B.get_class(obj), '__float__', $B.NULL)
-            if (float_method !== $B.NULL) {
-                x = $B.$call(float_method, obj)
-            }
         }
+        // CPython's float binary ops (CONVERT_TO_DOUBLE) accept ONLY
+        // int/float — no __float__ coercion: Decimal(5) + 2.2 must raise
+        // TypeError, it computed 7.2.
         res.push(x)
     }
     return res


### PR DESCRIPTION
```Python
>>> Decimal(5) + 2.2
Decimal('7.2')                                                               # before
>>> Decimal(5) + 2.2
TypeError: unsupported operand type(s) for +: 'decimal.Decimal' and 'float'  # after
```
