### PR TITLE
readinto(bytearray) works: is_buffer walks tp_mro, bytearray gets the buffer-protocol flag, BufferedReader reads fd-backed raws, array module calls its own funcs table

### DIFF
--- a/www/src/libs/array.js
+++ b/www/src/libs/array.js
@@ -195,7 +195,7 @@ array_funcs.__sizeof__ = function() {
 array_funcs.append = function(self, value) {
     $B.args("append", 2, {self: null, value: null}, arguments)
     var pos = self.obj === null ? 0 : self.obj.length
-    return array.insert(self, pos, value)
+    return array_funcs.insert(self, pos, value)
 }
 
 array_funcs.buffer_info = function() {
@@ -241,7 +241,7 @@ array_funcs.extend = function(self, iterable) {
         while (true) {
             try {
                 var item = _b_.next(it)
-                array.append(self, item)
+                array_funcs.append(self, item)
             } catch (err) {
                 $B.RAISE_IF_NOT(err, _b_.StopIteration)
                 break
@@ -272,7 +272,7 @@ array_funcs.fromlist = function(self, list) {
         try {
             var item = _b_.next(it)
             try {
-                array.append(self, item)
+                array_funcs.append(self, item)
             } catch (err) {
                 console.log(err)
                 return _b_.None
@@ -344,7 +344,7 @@ array_funcs.remove = function(self, x) {
     if (res == -1) {
         $B.RAISE(_b_.ValueError, "array.remove(x): x not in array")
     }
-    array.pop(self, res)
+    array_funcs.pop(self, res)
     return _b_.None
 }
 

--- a/www/src/py_bytes.js
+++ b/www/src/py_bytes.js
@@ -1605,6 +1605,8 @@ $B.set_func_names(bytearray, "builtins")
 //bytes() (built in function)
 var bytes = _b_.bytes
 bytes.$buffer_protocol = true
+// bytearray is THE canonical read-write buffer (readinto target)
+_b_.bytearray.$buffer_protocol = true
 bytes.$is_sequence = true
 
 function bytes_split_with_sep(cls, self, seps, maxsplit) {

--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -355,7 +355,8 @@ $B.is_buffer = function(obj) {
     if ($B.get_class(obj).$buffer_protocol) {
         return true
     }
-    for (var klass of $B.get_class(obj).__mro__) {
+    // Brython 3.14 classes store their MRO in tp_mro, not __mro__
+    for (var klass of $B.get_mro($B.get_class(obj))) {
         if (klass.$buffer_protocol) {
             return true
         }
@@ -446,6 +447,14 @@ function _bufferedreader_read_all(_self) {
 
 function _bufferedreader_read_fast(_self, n) {
     var raw = _self.raw
+    // raw streams without a preloaded $bytes snapshot: delegate to raw.read
+    if (raw.$bytes === undefined) {
+        var res = $B.$call($B.$getattr(raw, 'read'), n)
+        if (res === _b_.None || _b_.len(res) === 0) {
+            return _b_.None
+        }
+        return res
+    }
     if (raw.$byte_pos >= raw.$bytes.length) {
         return _b_.None
     }


### PR DESCRIPTION
```Python
>>> io.BufferedReader(io.BytesIO(b'hello')).readinto(bytearray(5))
JavascriptError: can't access property Symbol.iterator, ....__mro__ is undefined  # before
>>> io.BufferedReader(io.BytesIO(b'hello')).readinto(bytearray(5))
5                                                                                 # after
```