### PR TITLE
BufferedReader exposes its raw stream (tp_getset)

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -475,6 +475,8 @@ function _bufferedreader_readline(_self) {
 
 $B._BufferedReader = $B.make_builtin_class('_BufferedReader',
     [$B._BufferedIOBase])
+// expose the underlying raw stream, like CPython (decomp._buffer.raw.tell())
+$B._BufferedReader.tp_getset = ['raw']
 
 $B._BufferedReader.tp_init = function(_self, raw, buffer_size=DEFAULT_BUFFER_SIZE) {
     _self.raw = raw
@@ -482,6 +484,10 @@ $B._BufferedReader.tp_init = function(_self, raw, buffer_size=DEFAULT_BUFFER_SIZ
 }
 
 var _BufferedReader_funcs = $B._BufferedReader.tp_funcs = {}
+
+_BufferedReader_funcs.raw_get = function(_self) {
+    return _self.raw
+}
 
 _BufferedReader_funcs.peek = function(_self, size) {
     var $ = $B.args('peek', 2, {self: null, size: null}, arguments,


### PR DESCRIPTION
```Python
>>> io.BufferedReader(io.BytesIO(b'x')).raw
AttributeError: '_BufferedReader' object has no attribute 'raw'  # before
>>> io.BufferedReader(io.BytesIO(b'x')).raw
<_io.BytesIO object>                                             # after
```
