### PR TITLE
assertWarns: materialize str-recorded warnings from m.category (a raw str never isinstance-matches the expected category)

### DIFF
--- a/www/src/Lib/unittest/case.py
+++ b/www/src/Lib/unittest/case.py
@@ -318,6 +318,13 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
         first_matching = None
         for m in self.warnings:
             w = m.message
+            # Brython's _warnings shim records str messages as-is; CPython
+            # materializes category(message). A raw str never
+            # isinstance-matches, so assertWarns reported "not triggered"
+            # even when the warning fired.
+            if isinstance(w, str) and isinstance(m.category, type) \
+                    and issubclass(m.category, self.expected):
+                w = m.category(w)
             if not isinstance(w, self.expected):
                 continue
             if first_matching is None:


### PR DESCRIPTION
```Python
>>> with self.assertWarns(DeprecationWarning):
...     warnings.warn('x', DeprecationWarning)
AssertionError: DeprecationWarning not triggered  # before
>>> with self.assertWarns(DeprecationWarning):
...     warnings.warn('x', DeprecationWarning)
                                                  # after
```