### PR TITLE
__slots__: '__dict__' and '__weakref__' entries are markers, not slots ('__dict__' keeps the per-instance dict)

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -292,6 +292,12 @@ _b_.object.tp_setattro = function(self, attr, value) {
         }
     }
     var dict = $B.get_dict(self)
+    // a class whose __slots__ contains '__dict__' keeps a per-instance
+    // dict: create it lazily on the first out-of-slots setattr
+    if (! dict && klass.$slots_has_dict) {
+        self[$B.DICT] = $B.empty_dict()
+        dict = self[$B.DICT]
+    }
     if (dict) {
         $B.str_dict_set(dict, attr, value)
     } else {

--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1078,6 +1078,14 @@ function set_slots(cl_dict, class_obj) {
     let slots = $B.str_dict_get(cl_dict, '__slots__', $B.NULL)
     if (slots !== $B.NULL) {
         for (let key of $B.make_js_iterator(slots)) {
+            // CPython: '__dict__' / '__weakref__' inside __slots__ are
+            // markers, not slots — '__dict__' keeps the per-instance dict
+            if (key == '__dict__' || key == '__weakref__') {
+                if (key == '__dict__') {
+                    class_obj.$slots_has_dict = true
+                }
+                continue
+            }
             var member = {
                 name: key,
                 type: $B.TYPES.OBJECT,


### PR DESCRIPTION
```Python
>>> class S:
...     __slots__ = ('a', '__dict__')
>>> s = S()
>>> s.b = 2
AttributeError: 'S' object has no attribute 'b' and no __dict__ for setting new attributes  # before
>>> s.b = 2
>>> s.b                                                                                
2                                                                                           # after
```
