### PR TITLE
object.__getstate__: return (dict-or-None, {slot: value}) when __slots__ are filled (CPython 3.11+ pickle protocol)

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -554,6 +554,23 @@ object_funcs.__format__ = function() {
 
 object_funcs.__getstate__ = function(self) {
     var dict = $B.get_dict(self)
+    // CPython 3.11+: instances with filled __slots__ return a 2-tuple
+    // (dict-or-None, {slot: value}); slot values live as the member
+    // descriptors' slot_value_* properties
+    var sd = null
+    for (var k in self) {
+        if (k.startsWith('slot_value_') && self[k] !== undefined) {
+            if (sd === null) {
+                sd = $B.empty_dict()
+            }
+            _b_.dict.$setitem(sd, k.slice(11), self[k])
+        }
+    }
+    if (sd !== null) {
+        var d1 = (dict !== undefined && dict !== null &&
+            _b_.dict.mp_length(dict) > 0) ? dict : _b_.None
+        return $B.fast_tuple([d1, sd])
+    }
     return dict === undefined ? _b_.None : dict
 }
 


### PR DESCRIPTION
```Python
>>> class T:
...     __slots__ = ('a',)
>>> t = T()
>>> t.a = 1
>>> t.__getstate__()
None              # before
>>> t.__getstate__()
(None, {'a': 1})  # after
```
