### PR TITLE
bytes.__contains__: fix swapped indices (multi-byte needles never matched) and use native String.indexOf

### DIFF
--- a/www/src/py_bytes.js
+++ b/www/src/py_bytes.js
@@ -2578,20 +2578,19 @@ _b_.bytes.sq_contains = function(self, other) {
     if (self.source.length < other.source.length) {
         return false
     }
-    var len = other.source.length
-    for (var i = 0; i < self.source.length - other.source.length + 1; i++) {
-        var flag = true
-        for (var j = 0; j < len; j++) {
-            if (other.source[i + j] != self.source[j]) {
-                flag = false
-                break
-            }
+    // subsequence search via native String.indexOf — the previous loop
+    // compared the needle shifted against the start of the haystack
+    // (swapped indices), so multi-byte needles never matched; bytes map
+    // 1:1 to latin-1 code units (chunked to respect the arg-count limit)
+    var to_str = function(src) {
+        var parts = []
+        for (var k = 0; k < src.length; k += 32768) {
+            parts.push(String.fromCharCode.apply(null,
+                Array.prototype.slice.call(src, k, k + 32768)))
         }
-        if (flag) {
-            return true
-        }
+        return parts.join('')
     }
-    return false
+    return to_str(self.source).indexOf(to_str(other.source)) > -1
 }
 
 _b_.bytes.bf_getbuffer = function(self, flags) {


### PR DESCRIPTION
The old algorithm only ever matched at position 0. Just swapping the indices back gives a correct but naive O(n×m) search, which is too slow in practice. So the fix replaces the loop entirely: bytes map 1:1 to latin-1 code units, so both sequences are converted to JS strings and the search is delegated to native String.indexOf.

```Python
>>> b'hell' in b'hello world'
True   # before and after (position 0 accidentally worked)
>>> b'wor' in b'hello world'
False  # before
>>> b'wor' in b'hello world'
True   # after
```
