### PR TITLE
int.from_bytes: don't pre-complement the low byte (signed values with a high low-byte came out 256 short)

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -814,9 +814,9 @@ int_funcs.from_bytes = function(self) {
             "byteorder must be either 'little' or 'big'")
     }
     var num = _bytes[0]
-    if (signed && num >= 128) {
-        num = num - 256
-    }
+    // the sign lives in the MOST significant byte — handled at the end
+    // via the final two's-complement; pre-complementing the low byte
+    // subtracted 256 from every signed value whose low byte was >= 128
     num = BigInt(num)
     var _mult = 256n
     for (let i = 1;  i < _len; i++) {


### PR DESCRIPTION
```Python
>>> int.from_bytes(b'\xff\xff', 'little', signed=True)
-257  # before
>>> int.from_bytes(b'\xff\xff', 'little', signed=True)
-1    # after
```