### PR TITLE
class comparison honors a custom metaclass __eq__/__ne__ (identity shortcut only under plain type)

### DIFF
--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -1580,7 +1580,9 @@ $B.rich_comp = function(op, x, y) {
     }
     var res
 
-    if (x !== null && $B.is_type(x)) {
+    // classes compare by identity ONLY under plain `type`; a custom
+    // metaclass may define __eq__/__ne__
+    if (x !== null && $B.is_type(x) && $B.get_class(x) === _b_.type) {
         if (op == "__eq__") {
             return (x === y)
         } else if (op == "__ne__") {


### PR DESCRIPTION
```Python
>>> class Meta(type):
...     def __eq__(self, other):
...         return self.tag == other.tag
>>> A = Meta('X', (), {'tag': 1})
>>> B = Meta('X', (), {'tag': 1})
>>> A == B
False  # before
>>> A == B
True   # after
```
