### PR TITLE
int.__truediv__: correctly-rounded BigInt division, port of CPython long_true_divide ((2**1200)/(2**1100) returned nan, 1/2**1074 returned 0.0)

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -652,7 +652,50 @@ _b_.int.nb_true_divide = function(self, other) {
     if (y === 0n) {
         $B.RAISE(_b_.ZeroDivisionError, 'division by zero')
     }
-    return $B.fast_float(Number(x) / Number(y))
+    // Correctly-rounded BigInt division, port of CPython's
+    // long_true_divide (Objects/longobject.c). Converting each operand
+    // first (Number(x) / Number(y)) returned nan for operands >= 2**1024
+    // (Inf / Inf), lost precision above 2**53 (double rounding), and
+    // underflowed subnormal results to 0.0.
+    var negate = (x < 0n) != (y < 0n)
+    if (x < 0n) { x = -x }
+    if (y < 0n) { y = -y }
+    if (x === 0n) {
+        return $B.fast_float(negate ? -0.0 : 0.0)
+    }
+    var bx = x.toString(2).length,
+        by = y.toString(2).length,
+        diff = bx - by
+    var shift = Math.max(diff, -1021) - 55      // -1021 = DBL_MIN_EXP
+    var q, r
+    if (shift >= 0) {
+        var ys = y << BigInt(shift)
+        q = x / ys
+        r = x % ys
+    } else {
+        var xs = x << BigInt(-shift)
+        q = xs / y
+        r = xs % y
+    }
+    if (r !== 0n) {
+        q |= 1n                                 // sticky bit
+    }
+    var qbits = q.toString(2).length
+    var extra = Math.max(qbits, -1021 - shift) - 53  // 53 = DBL_MANT_DIG
+    var half = 1n << BigInt(extra - 1),
+        low = q & ((half << 1n) - 1n)
+    q >>= BigInt(extra)
+    if (low > half || (low === half && (q & 1n))) {
+        q += 1n                                 // round-half-to-even
+    }
+    shift += extra
+    // both factors are exactly representable, so the product is exact
+    var res = Number(q) * 2 ** shift
+    if (! isFinite(res)) {
+        $B.RAISE(_b_.OverflowError,
+            'integer division result too large for a float')
+    }
+    return $B.fast_float(negate ? -res : res)
 }
 
 _b_.int.nb_index = function(self) {


### PR DESCRIPTION
```Python
>>> (2**1200) / (2**1100)
nan                     # before
>>> (2**1200) / (2**1100)
1.2676506002282294e+30  # after
>>> 1 / 2**1074
0.0  # before
>>> 1 / 2**1074
5e-324  # after
```
