### PR TITLE
int subclass constructor converts its argument (MyInt(Fraction(17)) stored the raw Fraction as its value)

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -697,9 +697,11 @@ _b_.int.tp_new = function(cls, args, kw) {
     if (cls === int) {
         return int.$factory(value, base)
     }
+    // subclasses must convert the argument too: MyInt(Fraction(17))
+    // stored the raw Fraction as its value
     var res = {
         ob_type: cls,
-        value
+        value: int.$factory(value, base)
     }
     $B.init_dict(res)
     return res


### PR DESCRIPTION
```Python
>>> class MyInt(int): pass
...
>>> from fractions import Fraction
>>> MyInt(Fraction(17))
[object Object]  # before
>>> MyInt(Fraction(17))
17               # after
```
