### PR TITLE
_thread: 3.14 joinable-thread surface (start_joinable_thread handle/daemon kwargs, _ThreadHandle.join/is_done, sys.flags.thread_inherit_context) — threading.Thread.start() raised TypeError

### DIFF
--- a/www/src/Lib/_thread.py
+++ b/www/src/Lib/_thread.py
@@ -64,7 +64,11 @@ def start_new_thread(function, args, kwargs={}):
         _interrupt = False
         raise KeyboardInterrupt
 
-start_joinable_thread = start_new_thread # lazy
+def start_joinable_thread(function, handle=None, daemon=True):
+    """3.14 signature: threading.Thread.start() calls
+    _start_joinable_thread(bootstrap, handle=..., daemon=...)."""
+    start_new_thread(function, ())
+    return handle if handle is not None else _ThreadHandle()
 
 def _make_thread_handle(ident):
     return 999
@@ -102,7 +106,15 @@ def _is_main_interpreter():
     return True
 
 class _ThreadHandle:
-    pass
+    # threads run synchronously in start_joinable_thread, so a handle is
+    # always already done; threading.Thread relies on join()/is_done()
+    ident = -1
+
+    def join(self, timeout=None):
+        pass
+
+    def is_done(self):
+        return True
 
 
 class LockType(object):

--- a/www/src/Lib/sys.py
+++ b/www/src/Lib/sys.py
@@ -98,7 +98,8 @@ flags = make_dataclass('flags')(
       dev_mode = False,
       utf8_mode = 0,
       warn_default_encoding = 0,
-      context_aware_warnings = 0
+      context_aware_warnings = 0,
+      thread_inherit_context = 0
       )
 
 def getfilesystemencoding(*args, **kw):


### PR DESCRIPTION
```Python
>>> import threading
>>> threading.Thread(target=print).start()
TypeError: start_new_thread() got an unexpected keyword argument 'handle'  # before
>>> threading.Thread(target=print).start()
                                                                           # after
```
