### PR TITLE
_contextvars: Context.run was a repr string placeholder — threading targets never executed (TypeError 'str' object is not callable, swallowed by the thread excepthook)

### DIFF
--- a/www/src/Lib/_contextvars.py
+++ b/www/src/Lib/_contextvars.py
@@ -14,7 +14,9 @@ class Context(object):
 
     keys = "<method 'keys' of 'Context' objects>"
 
-    run = "<method 'run' of 'Context' objects>"
+    def run(self, callable, *args, **kwargs):
+        # single-threaded environment: just call (no context switching)
+        return callable(*args, **kwargs)
 
     values = "<method 'values' of 'Context' objects>"
 


### PR DESCRIPTION
```Python
>>> from contextvars import Context
>>> Context().run(lambda: 42)
TypeError: 'str' object is not callable  # before
>>> Context().run(lambda: 42)
42                                       # after
```
