### PR TITLE
_IOBase.tp_finalize: $B$call typo (ReferenceError on every __del__ of an open file) + leftover debug console.log

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -75,7 +75,6 @@ _IOBase.tp_iternext = function*(self){
 
 _IOBase.tp_finalize = function(self) {
     // Destructor.  Calls close()
-    console.log('del', self)
     try {
         var closed = $B.$getattr(self, 'closed')
     } catch (err) {
@@ -89,7 +88,7 @@ _IOBase.tp_finalize = function(self) {
         return
     }
 
-    $B$call($B.$getattr(self, 'close'))
+    $B.$call($B.$getattr(self, 'close'))
 }
 
 var _IOBase_funcs = _IOBase.tp_funcs = {}


### PR DESCRIPTION
```Python
>>> f = open('data.txt')
>>> f.__del__()
JavascriptError: $B$call is not defined  # before
>>> f.__del__()
                                         # after
```