### PR TITLE
_testcapi: add nan_msb_is_signaling = False (stub lacked it; IEEE-754 quiet NaN has the MSB set, not signaling — read by test_struct.test_half_float)

### DIFF
--- a/www/src/Lib/_testcapi.py
+++ b/www/src/Lib/_testcapi.py
@@ -42,6 +42,8 @@ ULONG_MAX = 4294967295
 
 USHRT_MAX = 65535
 
+nan_msb_is_signaling = False
+
 __loader__ = "<_frozen_importlib.ExtensionFileLoader object at 0x00C98DD0>"
 
 def _pending_threadfunc(*args,**kw):


### PR DESCRIPTION
```Python
>>> import _testcapi
>>> _testcapi.nan_msb_is_signaling
AttributeError: module '_testcapi' has no attribute 'nan_msb_is_signaling'  # before
>>> _testcapi.nan_msb_is_signaling
False                                                                       # after
```
