### PR TITLE
io: BytesIO.seekable() and writable() return True (were missing from tp_methods, so they inherited IOBase's False despite BytesIO_funcs defining them)

### DIFF
--- a/www/src/libs/_io_classes.js
+++ b/www/src/libs/_io_classes.js
@@ -755,7 +755,7 @@ BytesIO_funcs.seekable = function(_self) {
 BytesIO.tp_methods = [
     "__getstate__", "__setstate__", "getvalue", "getbuffer", "isatty", "close",
     "read", "read1", "readinto", "readline", "readlines", "write", "seek",
-    "tell", "truncate", "readable"
+    "tell", "truncate", "readable", "seekable", "writable"
 ]
 
 $B.set_func_names(BytesIO, '_io')


### PR DESCRIPTION
```Python
>>> from io import BytesIO
>>> BytesIO(b'x').seekable()
False   # before
>>> BytesIO(b'x').seekable()
True    # after
>>> BytesIO(b'x').writable()
False   # before
>>> BytesIO(b'x').writable()
True    # after
```
