### PR TITLE
float.hex(): lowercase mantissa digits

### DIFF
--- a/www/src/py_float.js
+++ b/www/src/py_float.js
@@ -1392,7 +1392,7 @@ float_funcs.hex = function(self) {
     _m = ldexp(fast_float(_m), _shift).value
     _e -= _shift
 
-    var _int2hex = "0123456789ABCDEF".split(""),
+    var _int2hex = "0123456789abcdef".split(""),
         _s = _int2hex[Math.floor(_m)]
     _s += '.'
     _m -= Math.floor(_m)


### PR DESCRIPTION
```Python
>>> (255.0).hex()
'0x1.FE00000000000p+7'  # before
>>> (255.0).hex()
'0x1.fe00000000000p+7'  # after
```
