### PR TITLE
random.randint: convert bounds via operator.index

### DIFF
--- a/www/src/Lib/random.py
+++ b/www/src/Lib/random.py
@@ -333,6 +333,8 @@ class Random(_random.Random):
         """Return random integer in range [a, b], including both end points.
         """
 
+        a = _index(a)
+        b = _index(b)
         return self.randrange(a, b+1)
 
 


### PR DESCRIPTION
```Python
>>> from random import randint
>>> class Idx:
...     def __index__(self): return 7
...
>>> randint(Idx(), Idx())
TypeError: unsupported operand type(s) for +: 'Idx' and 'int'  # before
>>> randint(Idx(), Idx())
7                                                              # after
```
