### PR TITLE
fix re — add PatternError alias (CPython 3.13+ name for re.error)

### DIFF
--- a/www/src/libs/python_re.js
+++ b/www/src/libs/python_re.js
@@ -3860,6 +3860,11 @@ var module = {
         return Pattern.$factory(jspat)
     },
     error: error,
+    // CPython 3.13+ alias — `re.error` was renamed to `re.PatternError`,
+    // with the old name kept as an alias. Tests written against 3.13+ use
+    // the new name (e.g. `assertRaises(re.PatternError, re.compile, …)`)
+    // and miss without this.
+    PatternError: error,
     escape: function() {
         var $ = $B.args("escape", 1, {pattern: null}, arguments)
         var data = prepare({pattern: $.pattern}),


### PR DESCRIPTION
```python
>>> re.PatternError is re.error
AttributeError: 'module' object has no attribute 'PatternError'  # before
>>> re.PatternError is re.error
True                                                             # after
```