### PR TITLE
Recognise 'iso8859' as a latin-1 alias

### DIFF
--- a/www/src/py_bytes.js
+++ b/www/src/py_bytes.js
@@ -2137,6 +2137,7 @@ var decode = $B.decode = function(obj, encoding, errors) {
           }
           return s
       case "latin_1":
+      case "iso8859":
       case "windows1252":
       case "iso-8859-1":
       case "iso8859-1":
@@ -2253,6 +2254,7 @@ var encode = $B.encode = function() {
         case "latin-1":
         case "latin_1":
         case "L1":
+        case "iso8859":
         case "iso8859_1":
         case "iso_8859_1":
         case "8859":


### PR DESCRIPTION
```python
>>> '\xe9'.encode('iso8859')
LookupError: unknown encoding: iso8859  # before
>>> '\xe9'.encode('iso8859')
b'\xe9'                                 # after
```
