### PR TITLE
io.BytesIO.close() calls _BufferedIOBase.tp_funcs.close, not the undefined _BufferedIOBase.close

### DIFF
--- a/www/src/libs/_io_classes.js
+++ b/www/src/libs/_io_classes.js
@@ -520,7 +520,7 @@ BytesIO_funcs.close = function(_self) {
         $B.$call($B.$getattr(_self._buffer, 'clear'))
     }
     _self.exports = 0
-    $B._BufferedIOBase.close(_self)
+    $B._BufferedIOBase.tp_funcs.close(_self)
 }
 
 BytesIO_funcs.read = function() {


### PR DESCRIPTION
```Python
>>> import io
>>> b = io.BytesIO(b'x'); b.close(); b.closed
JavascriptError: $B._BufferedIOBase.close is not a function  # before
>>> b = io.BytesIO(b'x'); b.close(); b.closed
True                                                         # after
```