### PR TITLE
io.BytesIO.readlines() returns a list, not a raw JS array

### DIFF
--- a/www/src/libs/_io_classes.js
+++ b/www/src/libs/_io_classes.js
@@ -636,7 +636,7 @@ BytesIO_funcs.readlines = function() {
             break
         }
     }
-    return lines
+    return $B.$list(lines)
 }
 
 BytesIO_funcs.write = function(_self, b) {


### PR DESCRIPTION
```Python
>>> import io
>>> isinstance(io.BytesIO(b'a\nb\n').readlines(), list)
False  # before
>>> isinstance(io.BytesIO(b'a\nb\n').readlines(), list)
True   # after
```
