### PR TITLE
io.UnsupportedOperation also subclasses ValueError (CPython: OSError, ValueError)

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -43,7 +43,7 @@ const DEFAULT_BUFFER_SIZE = (128 * 1024)  /* bytes */
 
 $B.make_IOUnsupported = function() {
     if ($B._IOUnsupported === undefined) {
-        $B._IOUnsupported = $B.make_type('UnsupportedOperation', [_b_.OSError])
+        $B._IOUnsupported = $B.make_type('UnsupportedOperation', [_b_.OSError, _b_.ValueError])
         $B._IOUnsupported.__module__ = '_io'
         $B.finalize_type($B._IOUnsupported)
     }


### PR DESCRIPTION
```Python
>>> import io
>>> issubclass(io.UnsupportedOperation, ValueError)
False  # before
>>> issubclass(io.UnsupportedOperation, ValueError)
True   # after
```
