### PR TITLE
io.BufferedReader.read() validates its arg via __index__ (read(1.0) now raises TypeError over a stream raw too)

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -537,6 +537,10 @@ function CHECK_CLOSED(fileobj, msg) {
 _BufferedReader_funcs.read = function(self, n=-1) {
     var res
 
+    if (n === _b_.None) {
+        n = -1
+    }
+    n = $B.PyNumber_Index(n)
     if (n < -1) {
         $B.RAISE(_b_.ValueError, "read length must be non-negative or -1")
     }


### PR DESCRIPTION
```Python
>>> import io
>>> class R(io.RawIOBase):
...     def readable(self): return True
...     def readinto(self, b): return 0
...
>>> io.BufferedReader(R()).read(1.0)
b''        # before
>>> io.BufferedReader(R()).read(1.0)
TypeError  # after
```
