### PR TITLE
getset descriptor: a non-callable setter (None or undefined) is read-only -> AttributeError, not 'self.setter is not a function'

### DIFF
--- a/www/src/descriptors.js
+++ b/www/src/descriptors.js
@@ -405,7 +405,9 @@ $B.getset_descriptor.$factory = function(klass, attr, getset) {
 
 /* getset_descriptor start */
 $B.getset_descriptor.tp_descr_set = function(self, obj, value) {
-    if (self.setter === _b_.None) {
+    // a getset with no callable setter (None, or omitted/undefined like the
+    // read-only 'raw' getset) is read-only: raise AttributeError, never call it
+    if (typeof self.setter !== 'function') {
         $B.RAISE_ATTRIBUTE_ERROR(
             `attribute '${self.d_name}' of '${self.d_type.tp_name}' objects is not writable`,
             self,


### PR DESCRIPTION
```python
>>> import io
>>> io.BytesIO(b'x').closed = True
JavascriptError: self.setter is not a function                           # before
>>> io.BytesIO(b'x').closed = True
AttributeError: attribute 'closed' of '_IOBase' objects is not writable  # after
```