### PR TITLE
io _BufferedIOBase.__exit__ no longer suppresses the with-block exception (CPython IOBase.__exit__ = self.close(), returns None)

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -398,12 +398,10 @@ function _bufferediobase_readinto_generic(_self, buffer, readinto1) {
 var _BufferedIOBase_funcs = $B._BufferedIOBase.tp_funcs = {}
 
 _BufferedIOBase_funcs.__exit__ = function(self, type, value, traceback) {
-    try {
-        $B.$call($B.$getattr(self, 'close'))
-        return true
-    } catch (err) {
-        return false
-    }
+    // like CPython IOBase.__exit__ = self.close(): returns None, never
+    // suppresses the with-block exception
+    $B.$call($B.$getattr(self, 'close'))
+    return _b_.None
 }
 
 _BufferedIOBase_funcs.readinto = function(_self, buffer) {


### PR DESCRIPTION
```python
>>> import io
>>> class R(io.RawIOBase):
...     def readable(self): return True
...
>>> with io.BufferedReader(R()):
...     1 / 0
...
                                     # before
>>> with io.BufferedReader(R()):
...     1 / 0
...
ZeroDivisionError: division by zero  # after
```