### PR TITLE
memoryview.nbytes uses the buffer's real itemsize, not the hard-coded 1 (was element count over an array('Q'))

### DIFF
--- a/www/src/memoryobject.js
+++ b/www/src/memoryobject.js
@@ -398,7 +398,16 @@ memoryview_funcs.nbytes_get = function(self) {
     for (var x of self.shape) {
         product *= x
     }
-    return x * self.itemsize
+    // factory stores itemsize 1 even over a multi-byte buffer (e.g. array('Q')):
+    // fall back to the source object's real itemsize so nbytes is the byte length
+    var isize = self.itemsize
+    if (isize === 1) {
+        var src = $B.$getattr(self.obj, 'itemsize', null)
+        if (src !== null && $B.is_int(src)) {
+            isize = src
+        }
+    }
+    return product * isize
 }
 
 memoryview_funcs.nbytes_set = _b_.None


### PR DESCRIPTION
```python
>>> import array
>>> memoryview(array.array('Q', [1, 2, 3, 4, 5])).nbytes
5   # before
>>> memoryview(array.array('Q', [1, 2, 3, 4, 5])).nbytes
40  # after
```
