### PR TITLE
bytes.decode('utf-8') keeps a leading BOM (TextDecoder defaults to stripping it)

### DIFF
--- a/www/src/py_bytes.js
+++ b/www/src/py_bytes.js
@@ -2002,7 +2002,7 @@ var decode = $B.decode = function(obj, encoding, errors) {
       case "U8":
       case "UTF":
           if (globalThis.TextDecoder) {
-              var decoder = new TextDecoder('utf-8', {fatal: true}),
+              var decoder = new TextDecoder('utf-8', {fatal: true, ignoreBOM: true}),
                   array = new Uint8Array(b)
               try {
                   return decoder.decode(array)


### PR DESCRIPTION
```python
>>> len('[1,2,3]'.encode('utf-8-sig').decode('utf-8'))
7   # before
>>> len('[1,2,3]'.encode('utf-8-sig').decode('utf-8'))
8   # after
```
