### PR TITLE
getNewArguments: call __getnewargs_ex__ via $B.$call, not a raw JS call (a bound method is an object, not a JS function)

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -146,7 +146,7 @@ object.$no_new_init = function(cls) {
 function getNewArguments(self, klass) {
     var newargs_ex = $B.$getattr(self, '__getnewargs_ex__', null)
     if (newargs_ex !== null) {
-        let newargs = newargs_ex()
+        let newargs = $B.$call(newargs_ex)
         if ((! newargs) || $B.get_class(newargs) !== _b_.tuple) {
             $B.RAISE(_b_.TypeError, "__getnewargs_ex__ should " +
                 `return a tuple, not '${$B.class_name(newargs)}'`)


### PR DESCRIPTION
```python
>>> import pickle
>>> class C:
...     def __getnewargs_ex__(self):
...         return (), {}
...
>>> isinstance(pickle.dumps(C(), 2), bytes)
JavascriptError: newargs_ex is not a function  # before
>>> isinstance(pickle.dumps(C(), 2), bytes)
True                                           # after
```
