### PR TITLE
object: __reduce_ex__ uses copyreg.__newobj_ex__ when __getnewargs_ex__ returns keyword args (was always __newobj__, dropping the kwargs)

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -656,7 +656,12 @@ object_funcs.__reduce_ex__ = function(self, protocol) {
     var arg2 = [klass]
     var newargs = getNewArguments(self, klass)
     if (newargs) {
-        arg2 = arg2.concat(newargs.args)
+        if (newargs.kwargs && _b_.dict.mp_length(newargs.kwargs) > 0) {
+            res = [$B.module_getattr($B.imported.copyreg, '__newobj_ex__')]
+            arg2 = [klass, newargs.args, newargs.kwargs]
+        } else {
+            arg2 = arg2.concat(newargs.args)
+        }
     }
     res.push($B.fast_tuple(arg2))
     var getstate = $B.search_in_mro(klass, '__getstate__')


### PR DESCRIPTION
Depends on #2794 that must be merged first. Without it, __reduce_ex__ raises newargs_ex is not a function in getNewArguments before ever reaching this code, so the '__newobj__' "before" below is only reproducible with that fix applied.

```python
>>> class S:
...     def __getnewargs_ex__(self): return ((), {'x': 1})
...
>>> S().__reduce_ex__(2)[0].__name__
'__newobj__'     # before
>>> S().__reduce_ex__(2)[0].__name__
'__newobj_ex__'  # after
```
