### PR TITLE
make the __getitem__-based iterator picklable: __reduce__ returns (iter, (seq,), index) and __setstate__ restores that index (both were empty stubs), so a partially-consumed seqiterator resumes at its position

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1169,11 +1169,12 @@ iterator_funcs.__length_hint__ = function(self) {
 }
 
 iterator_funcs.__reduce__ = function(self) {
-
+    return $B.fast_tuple([_b_.iter,
+        $B.fast_tuple([self.it_seq]), self.it_index])
 }
 
-iterator_funcs.__setstate__ = function(self) {
-
+iterator_funcs.__setstate__ = function(self, state) {
+    self.it_index = state < 0 ? 0 : state
 }
 
 $B.iterator.tp_methods = ["__length_hint__", "__reduce__", "__setstate__"]


### PR DESCRIPTION
```python
>>> class S:
...     def __len__(self): return 5
...     def __getitem__(self, i):
...         if i > 4: raise IndexError
...         return i * 10
...
>>> it = iter(S())
>>> next(it)
0
>>> next(it)
10
>>> import pickle
>>> next(pickle.loads(pickle.dumps(it)))
PicklingError: __reduce__ must return a string or tuple, not Undefined  # before
>>> next(pickle.loads(pickle.dumps(it)))
20                                                                       # after
```