### PR TITLE
type.__qualname__ returns the type name when a builtin descriptor type stores an instance __qualname__ getset under the same dict key (method_descriptor.__qualname__ returned the descriptor, not 'method_descriptor')

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1736,7 +1736,10 @@ type_funcs.__prepare__ = function(cls) {
 }
 
 type_funcs.__qualname___get = function(cls) {
-    return $B.get_from_dict(cls, '__qualname__', $B.get_name(cls))
+    // builtin descriptor types store their instance __qualname__ getset under
+    // the same dict key; use the dict value only when it is the qualname string
+    var q = $B.get_from_dict(cls, '__qualname__', $B.NULL)
+    return typeof q === 'string' ? q : $B.get_name(cls)
 }
 
 type_funcs.__qualname___set = function(cls, value) {


### PR DESCRIPTION
```python
>>> type(str.count).__qualname__
<attribute '__qualname__' of 'method_descriptor' objects>  # before
>>> type(str.count).__qualname__
'method_descriptor'                                        # after
```