### PR TITLE
int: raise ZeroDivisionError for 0 ** negative instead of returning inf (JS 0 ** -1 is Infinity)

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -522,6 +522,10 @@ _b_.int.nb_power = function(self, other, z) {
             return int_or_long(result)
         } else {
             if (y < 0n) {
+                if (x == 0n) {
+                    $B.RAISE(_b_.ZeroDivisionError,
+                        "zero to a negative power")
+                }
                 // raising a BigInt to a negative values raises a JS error
                 return $B.fast_float(Number(x) ** Number(y))
             }


### PR DESCRIPTION
```python
>>> 0 ** -1
inf                                          # before
>>> 0 ** -1
ZeroDivisionError: zero to a negative power  # after
```