### PR TITLE
property: __set__ on a read-only property falls back to the property name when the getter has no $function_infos (built-in/descriptor getter) instead of crashing

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1839,7 +1839,8 @@ property.$factory = function(fget, fset, fdel, doc) {
 /* property start */
 _b_.property.tp_descr_set = function(self, obj, value) {
     if (self.prop_set === _b_.None) {
-        var name = self.prop_get.$function_infos[$B.func_attrs.__name__]
+        var fi = self.prop_get.$function_infos
+        var name = fi ? fi[$B.func_attrs.__name__] : (self.prop_name ?? self.__name__)
         var msg = `property '${name}' of '${$B.class_name(obj)}' object ` +
                   'has no setter'
         $B.RAISE_ATTRIBUTE_ERROR(msg, self, '__set__')


### PR DESCRIPTION
```python
>>> class C:
...     x = property(str.upper)
...
>>> C().x = 5
JavascriptError: ... self.prop_get.$function_infos is undefined  # before
>>> C().x = 5
AttributeError: property 'upper' of 'C' object has no setter     # after
```