### PR TITLE
io: BufferedReader.seek raises UnsupportedOperation('File or stream is not seekable.') when the underlying stream is not seekable, instead of silently delegating to the raw stream

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -551,6 +551,10 @@ _BufferedReader_funcs.seek = function(_self, offset, whence) {
     if (whence === undefined) {
         whence = 0
     }
+    // like CPython, seeking an unseekable stream raises UnsupportedOperation
+    if (! $B.$bool($B.$call($B.$getattr(_self, 'seekable')))) {
+        _io_unsupported('File or stream is not seekable.')
+    }
     var raw = _self.raw
     // a raw stream without a $bytes snapshot seeks itself; otherwise move the
     // cursor read() consults on the raw object


### PR DESCRIPTION
```Python
>>> import io
>>> class NotSeekable(io.RawIOBase):
...     def readable(self): return True
...     def seekable(self): return False
...     def readinto(self, b): return 0
...
>>> io.BufferedReader(NotSeekable()).seek(0)               # before: returns None, no error
>>> io.BufferedReader(NotSeekable()).seek(0)               # after
io.UnsupportedOperation: File or stream is not seekable.

```