### PR TITLE
itertools: repeat coerces times via operator.index so an object with __index__ works (repeat(obj, MyIndex(5))) — it used range(times) only as a TypeError check and then compared the original object in times < 0

### DIFF
--- a/www/src/Lib/itertools.py
+++ b/www/src/Lib/itertools.py
@@ -392,7 +392,7 @@ class repeat:
     def __init__(self, obj, times=None):
         self._obj = obj
         if times is not None:
-            range(times) # Raise a TypeError
+            times = operator.index(times) # coerce via __index__, TypeError otherwise
             if times < 0:
                 times = 0
         self._times = times


### PR DESCRIPTION
```python
>>> import itertools
>>> class Ix:
...     def __index__(self): return 3
>>> list(itertools.repeat(9, Ix()))
TypeError                                                # before
>>> list(itertools.repeat(9, Ix()))
[9, 9, 9]                                                # after
```
