### PR TITLE
int: int.from_bytes(b'') returns 0 instead of crashing — the empty input read _bytes[0] (undefined) into BigInt(), raising a JS error

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -866,6 +866,9 @@ int_funcs.from_bytes = function(self) {
         $B.RAISE(_b_.ValueError,
             "byteorder must be either 'little' or 'big'")
     }
+    if (_len == 0) {
+        return 0
+    }
     var num = _bytes[0]
     // the sign lives in the MOST significant byte — handled at the end
     // via the final two's-complement; pre-complementing the low byte


### PR DESCRIPTION
```python
>>> int.from_bytes(b'', 'big')
JavascriptError: Cannot convert undefined to a BigInt   # before
>>> int.from_bytes(b'', 'big')
0                                                       # after
```