### PR TITLE
hashlib: bytes2WordArray accepts a bytearray and raises through $B.RAISE — it rejected bytearray and 'throw _b_.TypeError(...)' called a type object as a function, raising a JS error instead of a Python TypeError

### DIFF
--- a/www/src/libs/hashlib.js
+++ b/www/src/libs/hashlib.js
@@ -63,8 +63,8 @@ function $get_CryptoJS_lib(alg) {
 function bytes2WordArray(obj) {
     // Transform a bytes object into an instance of class WordArray
     // defined in CryptoJS
-    if (!$B.is_bytes(obj)) {
-        throw _b_.TypeError("expected bytes, got " + $B.class_name(obj))
+    if (! $B.$isinstance(obj, [_b_.bytes, _b_.bytearray])) {
+        $B.RAISE(_b_.TypeError, "expected bytes, got " + $B.class_name(obj))
     }
 
     let words = []


### PR DESCRIPTION
```python
>>> import hashlib
>>> hashlib.md5(bytearray(b'x')).hexdigest()
JavascriptError: _b_.TypeError is not a function          # before
>>> hashlib.md5(bytearray(b'x')).hexdigest()
'9dd4e461268c8034f5c8564e155c67a6'                        # after
```
