### PR TITLE
posix: os.urandom validates its argument like CPython — integer-only (TypeError on float via __index__), ValueError on a negative count, OverflowError when it does not fit, instead of letting Uint8Array raise a raw JS error or silently truncate

### DIFF
--- a/www/src/libs/posix.js
+++ b/www/src/libs/posix.js
@@ -142,6 +142,15 @@ var module = {
         return stat_result.$factory(filename)
     },
     urandom: function(n) {
+        n = $B.PyNumber_Index(n) // integer only: TypeError on float
+        if (n < 0) {
+            $B.RAISE(_b_.ValueError, "negative argument not allowed")
+        }
+        n = Number(n)
+        if (! Number.isSafeInteger(n)) {
+            $B.RAISE(_b_.OverflowError,
+                "cannot fit 'int' into an index-sized integer")
+        }
         const randbytes = new Uint8Array(n);
         crypto.getRandomValues(randbytes);
         return _b_.bytes.$factory(Array.from(randbytes))


### PR DESCRIPTION
```python
>>> import os
>>> os.urandom(-1)
JavascriptError: invalid array length                    # before
>>> os.urandom(-1)
ValueError: negative argument not allowed                # after
>>> os.urandom(1.5)
b''                                                             # before
>>> os.urandom(1.5)
TypeError: 'float' object cannot be interpreted as an integer   # after
```
