### PR TITLE
int: int(float) raises ValueError for NaN and OverflowError for Infinity instead of returning the float unchanged — float has no __int__, so int() fell through to __trunc__ which kept NaN/inf

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -198,6 +198,19 @@ int.$factory = function(value, base) {
             $B.RAISE(_b_.TypeError,
                 "int() can't convert non-string with explicit base")
         } else {
+            if ($B.$isinstance(value, _b_.float)) {
+                // float has no __int__, so int() would fall through to
+                // __trunc__ and return NaN/Infinity unchanged
+                var _fv = typeof value == 'number' ? value : value.value
+                if (isNaN(_fv)) {
+                    $B.RAISE(_b_.ValueError,
+                        'cannot convert float NaN to integer')
+                }
+                if (! isFinite(_fv)) {
+                    $B.RAISE(_b_.OverflowError,
+                        'cannot convert float infinity to integer')
+                }
+            }
             // booleans, bigints, objects with method __index__
             for (let special_method of ['__int__', '__index__', '__trunc__']) {
                 let num_value = $B.$getattr($B.get_class(value),


### PR DESCRIPTION
```python
>>> int(float('nan'))
nan                                                      # before
>>> int(float('nan'))
ValueError: cannot convert float NaN to integer          # after
>>> int(float('inf'))
inf                                                      # before
>>> int(float('inf'))
OverflowError: cannot convert float infinity to integer  # after
```
