### PR TITLE
Fix bound method-wrapper __name__ returning the bound object's name

### DIFF
--- a/www/src/descriptors.js
+++ b/www/src/descriptors.js
@@ -26,7 +26,7 @@ $B.method_wrapper.tp_call = function(self, ...args) {
 var method_wrapper_funcs = $B.method_wrapper.tp_funcs = {}
 
 method_wrapper_funcs.__name___get = function(self) {
-    return self.self.__name__
+    return self.d_name
 }
 
 method_wrapper_funcs.__name___set = function(self) {


### PR DESCRIPTION
```python
>>> "".__len__.__name__ == '__len__'
False  # before
>>> "".__len__.__name__ == '__len__'
True   # after
```
