### PR TITLE
Fix object.__setattr__ accepting a non-string attribute name

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -234,6 +234,10 @@ _b_.object.tp_richcompare = function(self, other, op) {
 _b_.object.tp_setattro = function(self, attr, value) {
     var test = false // attr == 'x' // && value === $B.NULL
     var klass = $B.get_class(self)
+    if (! $B.is_str(attr)) {
+        $B.RAISE(_b_.TypeError, "attribute name must be string, not '" +
+            $B.class_name(attr) + "'")
+    }
     var in_mro = $B.search_in_mro(klass, attr, $B.NULL)
     if (test) {
         console.log('object.tp_setattro', self, attr, value)


### PR DESCRIPTION
```python
>>> object().__setattr__(range(3), 0)
AttributeError: 'object' object has no attribute '[object Object]'  # before
>>> object().__setattr__(range(3), 0)
TypeError: attribute name must be string, not 'range'               # after
```