### PR TITLE
Fix compilation of t-string debug expressions (t"{x=}")

### DIFF
--- a/www/src/action_helpers.js
+++ b/www/src/action_helpers.js
@@ -354,15 +354,14 @@ $B._PyPegen.interpolation = function(p, expression,
         return interpolation
     }
 
-    var debug_text = $B._PyAST.Constant(debug_metadata)
+    var debug_text = new $B.ast.Constant(debug_metadata)
     set_position_from_list(debug_text,
         [lineno, col_offset + 1, debug_end_line, debug_end_offset - 1])
 
     var values = [debug_text, interpolation]
-    var ast_obj = $B._PyAST.JoinedStr(values)
+    var ast_obj = new $B.ast.JoinedStr(values)
     set_position_from_list(ast_obj,
         [lineno, col_offset, debug_end_line, debug_end_offset])
-    console.log('JoinedStr', ast_obj)
     return ast_obj
 }
 


### PR DESCRIPTION
```python
>>> t"{1=}".strings[0]
JavascriptError: PyErr_Format is not defined  # before
>>> t"{1=}".strings[0]
'1='                                          # after
```
