### PR TITLE
Fix 3-argument pow() returning undefined for a non-int/float/complex base

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1610,14 +1610,19 @@ _b_.pow = function() {
                 } else if (! $B.is_int(z)) {
                     throw all_ints()
                 }
+                return _b_.int.nb_power(x, y, z)
             }
-            return _b_.int.nb_power(x, y, z)
         } else if ($B.$isinstance(x, _b_.float)) {
             throw all_ints()
         } else if ($B.$isinstance(x, _b_.complex)) {
             throw complex_modulo()
         }
     }
+    var res = $B.$call($B.$getattr(x, '__pow__'), y, z)
+    if (res !== _b_.NotImplemented) {
+        return res
+    }
+    return $B.$call($B.$getattr(y, '__rpow__'), x, z)
 }
 
 var $print = _b_.print = function() {

--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1622,7 +1622,13 @@ _b_.pow = function() {
     if (res !== _b_.NotImplemented) {
         return res
     }
-    return $B.$call($B.$getattr(y, '__rpow__'), x, z)
+    var rres = $B.$call($B.$getattr(y, '__rpow__'), x, z)
+    if (rres !== _b_.NotImplemented) {
+        return rres
+    }
+    throw $B.EXC(_b_.TypeError,
+        "unsupported operand type(s) for pow(): '" + $B.class_name(x) +
+        "', '" + $B.class_name(y) + "', '" + $B.class_name(z) + "'")
 }
 
 var $print = _b_.print = function() {


### PR DESCRIPTION
```python
>>> from decimal import Decimal
>>> pow(Decimal(10), 2, 7)
<Javascript undefined>  # before
>>> pow(Decimal(10), 2, 7)
Decimal('2')            # after
```
