### PR TITLE
Fix int() dropping the sign for a string of non-ASCII Unicode digits

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -354,6 +354,9 @@ int.$factory = function(value, base) {
                 invalid(base)
             }
         }
+        if (sign == '-') {
+            res = $B.rich_op('__mul__', res, -1)
+        }
         return res
     } else {
         _value = _value.replace(/_/g, "")


### PR DESCRIPTION
```python
>>> int('-\u0663')
3   # before
>>> int('-\u0663')
-3  # after
```