### PR TITLE
Fix <class>.__class__ returning the getset descriptor instead of the metaclass

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -849,6 +849,9 @@ $B.$getattr = function(obj, attr, _default) {
         }
         var res = $B.object_getattribute(obj, klass, attr)
     } else {
+        if (attr === '__class__') {
+            return $B.get_class(obj)
+        }
         var in_dict = $B.get_dict(obj)[attr]
         if (in_dict && $B.get_class(obj) === _b_.type) {
             var res = $B.NULL


### PR DESCRIPTION
```python
>>> object.__class__
<attribute '__class__' of 'object' objects>  # before
>>> object.__class__
<class 'type'>                               # after
```
