### PR TITLE
f-string: re-box the joined result with $B.String so an astral codepoint counts as one character

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -3134,7 +3134,10 @@ $B.ast.JoinedStr.prototype.to_js = function(scopes) {
     if (items.length == 0) {
         return "''"
     }
-    return items.join(' + ')
+    // Re-box with $B.String (like str.sq_concat): joining with JS '+' drops the
+    // surrogate marking of an astral codepoint, so len() / indexing would treat
+    // it as 2 characters.
+    return '$B.String(' + items.join(' + ') + ')'
 }
 
 $B.ast.Lambda.prototype.to_js = function(scopes) {


### PR DESCRIPTION
```python
>>> u = 'z\U0001d120x'
>>> len(f'"{u}"')
6  # before
>>> len(f'"{u}"')
5  # after
```