### PR TITLE
IterableJavascriptObject: support next() without a prior iter() (lazily set self.it in __next__)

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -1018,6 +1018,11 @@ $B.IterableJSObj.sq_length = function(self) {
 }
 
 $B.IterableJSObj.tp_iternext = function*(self){
+    if (self.it === undefined) {
+        // next(it) can be called without iter(it) first — __iter__ (tp_iter) is
+        // what normally sets self.it, but __next__ must stand on its own.
+        self.it = self[Symbol.iterator]()
+    }
     for (var value of self.it) {
         yield value
     }


### PR DESCRIPTION
```python
>>> from browser import window
>>> next(window.Set.new([3, 1, 4]))
JavascriptError: can't access property "Symbol.iterator", self.it is undefined  # before
>>> next(window.Set.new([3, 1, 4]))
3                                                                               # after
```
