### PR TITLE
string: recompute astral surrogate positions on the evaluated literal

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -2070,7 +2070,12 @@ $B.ast.Constant.prototype.to_js = function() {
         if (srg.length == 0) {
             return `'${s}'`
         }
-        return `$B.make_String('${s}', [${srg}])`
+        // Box at runtime so the surrogate positions are computed on the
+        // evaluated string literal, not on the escaped source s (see
+        // $B.surrogates): emitting the positions here used the escaped form
+        // and put them off by one for any literal with a backslash before an
+        // astral character.
+        return `$B.String('${s}')`
     }
     var klass = $B.get_class(this.value)
     if (klass === _b_.bytes) {

--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -14,29 +14,16 @@ var escape2cp = $B.escape2cp = {
 }
 
 $B.surrogates = function(s) {
-    var s1 = '',
-        escaped = false
-    for (var char of s) {
-        if (escaped) {
-            var echar = escape2cp[char]
-            if (echar !== undefined) {
-                s1 += echar
-            } else {
-                s1 += '\\' + char
-            }
-            escaped = false
-        } else if (char == '\\') {
-            escaped = true
-        } else {
-            s1 += char
-        }
-    }
-
+    // Code point positions of the astral characters in s (each takes two
+    // UTF-16 units). s is the actual string value; the positions are
+    // recomputed here, on the evaluated value, rather than on the escaped
+    // source form, where re-resolving escapes diverged from JS string-literal
+    // evaluation ('\\' was counted as two code points instead of one,
+    // shifting every later astral position by one).
     var surrogates = [],
         j = 0
-
-    for (var i = 0, len = s1.length; i < len; i++) {
-        var cp = s1.codePointAt(i)
+    for (var i = 0, len = s.length; i < len; i++) {
+        var cp = s.codePointAt(i)
         if (cp >= 0x10000) {
             surrogates.push(j)
             i++


### PR DESCRIPTION
```Python
>>> s = '\\g<𝔘>'  # '\', 'g', '<', U+1D518, '>'
>>> hex(ord(s[4]))
'0xdd18'  # before
>>> hex(ord(s[4]))
'0x3e'    # after
```