### PR TITLE
set io.UnsupportedOperation.__module__ in the type dict so finalize_type keeps it (it was a JS property, overwritten with 'builtins')

### DIFF
--- a/www/src/py_io.js
+++ b/www/src/py_io.js
@@ -44,7 +44,7 @@ const DEFAULT_BUFFER_SIZE = (128 * 1024)  /* bytes */
 $B.make_IOUnsupported = function() {
     if ($B._IOUnsupported === undefined) {
         $B._IOUnsupported = $B.make_type('UnsupportedOperation', [_b_.OSError, _b_.ValueError])
-        $B._IOUnsupported.__module__ = '_io'
+        $B.set_to_dict($B._IOUnsupported, '__module__', 'io')
         $B.finalize_type($B._IOUnsupported)
     }
 }


### PR DESCRIPTION
```python
>>> import io
>>> io.UnsupportedOperation.__module__
'builtins'  # before
>>> io.UnsupportedOperation.__module__
'io'        # after
```