### PR TITLE
compute __qualname__ of a class or method nested 2+ levels deep correctly

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1518,11 +1518,11 @@ _b_.type.tp_new = function(cls, args, kw) {
                 if (v.$function_infos === undefined) {
                     // internal functions have $infos
                     if (v.$infos) {
-                        v.$infos.__qualname__ = name + '.' + v.$infos.__name__
+                        v.$infos.__qualname__ = qualname + '.' + v.$infos.__name__
                     }
                 } else {
                     v.$function_infos[$B.func_attrs.method_class] = class_obj
-                    v.$function_infos[$B.func_attrs.__qualname__] = name + '.' +
+                    v.$function_infos[$B.func_attrs.__qualname__] = qualname + '.' +
                         v.$function_infos[$B.func_attrs.__name__]
                 }
             }

--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -47,7 +47,9 @@ $B.$class_constructor = function(class_name, dict, metaclass, resolved_bases,
         stack.push(frame_obj.frame[0] + '.')
         frame_obj = frame_obj.prev
     }
-    var qualname = `${stack.join('')}${class_name}`
+    // the frames were walked innermost-first; the qualname prefix is
+    // outermost-first (Outer.Inner.Deep, not Inner.Outer.Deep)
+    var qualname = `${stack.reverse().join('')}${class_name}`
     $B.str_dict_set(dict, '__qualname__', qualname)
 
     // A class that overrides __eq__() and does not define __hash__()


### PR DESCRIPTION
```python
>>> class Outer:
...     class Inner:
...         class Deep: pass
...         
>>> Outer.Inner.Deep.__qualname__
'Inner.Outer.Deep'  # before
>>> Outer.Inner.Deep.__qualname__
'Outer.Inner.Deep'  # after
```
