### PR TITLE
_pydecimal: support fractional-digit grouping separators and allow leading zeros in the precision/width of the format specifier

### DIFF
--- a/www/src/Lib/_pydecimal.py
+++ b/www/src/Lib/_pydecimal.py
@@ -6120,9 +6120,13 @@ _parse_format_specifier_regex = re.compile(r"""\A
 (?P<no_neg_0>z)?
 (?P<alt>\#)?
 (?P<zeropad>0)?
-(?P<minimumwidth>(?!0)\d+)?
+(?P<minimumwidth>\d+)?
 (?P<thousands_sep>[,_])?
-(?:\.(?P<precision>0|(?!0)\d+))?
+(?:\.
+    (?=[\d,_])  # lookahead for digit or separator
+    (?P<precision>\d+)?
+    (?P<frac_separators>[,_])?
+)?
 (?P<type>[eEfFgGn%])?
 \z
 """, re.VERBOSE|re.DOTALL)
@@ -6214,6 +6218,9 @@ def _parse_format_specifier(format_spec, _localeconv=None):
             format_dict['thousands_sep'] = ''
         format_dict['grouping'] = [3, 0]
         format_dict['decimal_point'] = '.'
+
+    if format_dict['frac_separators'] is None:
+        format_dict['frac_separators'] = ''
 
     return format_dict
 
@@ -6333,6 +6340,11 @@ def _format_number(is_negative, intpart, fracpart, exp, spec):
     """
 
     sign = _format_sign(is_negative, spec)
+
+    frac_sep = spec['frac_separators']
+    if fracpart and frac_sep:
+        fracpart = frac_sep.join(fracpart[pos:pos + 3]
+                                 for pos in range(0, len(fracpart), 3))
 
     if fracpart or spec['alt']:
         fracpart = spec['decimal_point'] + fracpart


### PR DESCRIPTION
```python
>>> from decimal import Decimal
>>> format(Decimal('123456'), ',.4_e')
ValueError: Invalid format specifier: ,.4_e  # before
>>> format(Decimal('123456'), ',.4_e')
'1.234_6e+5'                                 # after
```