### PR TITLE
sys.hash_info: report the real 64-bit width and 2**61-1 modulus (was 32-bit / 2**31-1)

### DIFF
--- a/www/src/Lib/sys.py
+++ b/www/src/Lib/sys.py
@@ -253,8 +253,8 @@ implementation = SimpleNamespace(
     )
 
 hash_info = make_dataclass('hash_info')(
-      width = 32,
-      modulus = 2147483647,
+      width = 64,
+      modulus = 2305843009213693951,
       inf = 314159,
       nan = 0,
       imag = 1000003,


### PR DESCRIPTION
```python
>>> import sys
>>> sys.hash_info.modulus
2147483647           # before
>>> sys.hash_info.modulus
2305843009213693951  # after
```