### PR TITLE
type.__qualname__ setter writes the class dict so a reassigned __qualname__ is honored by getattr

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1743,6 +1743,9 @@ type_funcs.__qualname___get = function(cls) {
 }
 
 type_funcs.__qualname___set = function(cls, value) {
+    // write the dict, where __qualname___get reads it (tp_name alone left the
+    // getter returning the stale auto-computed qualname); keep tp_name for repr
+    $B.set_to_dict(cls, '__qualname__', value)
     cls.tp_name = value
 }
 


### PR DESCRIPTION
```Python
>>> class C: pass
>>> C.__qualname__ = 'A.B.C'
>>> C.__qualname__
'C'      # before
>>> C.__qualname__
'A.B.C'  # after
```