### PR TITLE
set/frozenset subclasses get an instance __dict__ + set.__reduce__ returns the instance __dict__ as state (not None)

### DIFF
--- a/www/src/py_set.js
+++ b/www/src/py_set.js
@@ -625,9 +625,11 @@ set_funcs.__class_getitem__ = function(cls, items) {
 }
 
 set_funcs.__reduce__ = function(self) {
+    // carry the instance __dict__ as state (like CPython's set_reduce), not None
+    var d = $B.get_dict(self)
     return $B.fast_tuple([$B.get_class(self),
                          $B.fast_tuple([set_make_items(self)]),
-                         _b_.None])
+                         d && _b_.len(d) ? d : _b_.None])
 }
 
 set_funcs.__sizeof__ = function(self) {

--- a/www/src/py_set.js
+++ b/www/src/py_set.js
@@ -566,7 +566,12 @@ _b_.set.tp_init = function(self, iterable) {
 _b_.set.tp_new = function(cls, args, kw) {
     var [iterable] = $B.unpack_args('set', args, ['iterable'],
         {iterable: _b_.None})
-    return make_new_set(cls)
+    var res = make_new_set(cls)
+    // a subclass instance gets a __dict__, like list/dict/float/tuple
+    if (cls !== _b_.set) {
+        $B.init_dict(res)
+    }
+    return res
 }
 
 _b_.set.nb_inplace_subtract = function(self, other) {
@@ -944,6 +949,9 @@ frozenset.tp_new = function(cls, args, kw) {
     var [iterable] = $B.unpack_args('frozenset', args, ['iterable'],
         {iterable: _b_.None})
     var self = make_new_set(cls)
+    if (cls !== frozenset) {
+        $B.init_dict(self)
+    }
 
     if (iterable === _b_.None) {
         return self


### PR DESCRIPTION
```Python
>>> class S(set): pass
>>> S().__dict__
<undefined>  # before
>>> S().__dict__
{}           # after
>>> import pickle
>>> class S(set): pass
>>> s = S([1, 2]); s.foo = 9; pickle.loads(pickle.dumps(s)).foo
None  # before
>>> s = S([1, 2]); s.foo = 9; pickle.loads(pickle.dumps(s)).foo
9     # after
```