### PR TITLE
map.__reduce__: return (map, (func, *iterables)) so a map can be pickled (it returned undefined, crashing pickle)

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1381,14 +1381,16 @@ _b_.map.tp_new = function(cls, args, kw) {
     return {
         ob_type: cls,
         args: iter_args,
-        func: func
+        func: func,
+        iterables: [it1, ...extra_args]
     }
 }
 
 var map_funcs = _b_.map.tp_funcs = {}
 
 map_funcs.__reduce__ = function(self) {
-
+    return $B.fast_tuple([$B.get_class(self),
+        $B.fast_tuple([self.func, ...(self.iterables || [])])])
 }
 
 map_funcs.__setstate__ = function(self) {


### PR DESCRIPTION
```python
>>> import pickle
>>> list(pickle.loads(pickle.dumps(map(int, '123'))))
pickle.PicklingError: __reduce__ must return a string or tuple, not NoneType  # before
>>> list(pickle.loads(pickle.dumps(map(int, '123'))))
[1, 2, 3]                                                                     # after
```