### PR TITLE
defaultdict.__reduce__: the 5th item (dictitems) must be an iterator, not a dict_items view

### DIFF
--- a/www/src/Lib/_collections.py
+++ b/www/src/Lib/_collections.py
@@ -438,7 +438,7 @@ class defaultdict(dict):
 
         #   This API is used by pickle.py and copy.py.
         #
-        return (type(self), (self.default_factory,), None, None, self.items())
+        return (type(self), (self.default_factory,), None, None, iter(self.items()))
 
 from operator import itemgetter as _itemgetter
 from keyword import iskeyword as _iskeyword


### PR DESCRIPTION
```python
>>> import collections
>>> type(collections.defaultdict().__reduce__()[4]).__name__
'dict_items'         # before
>>> type(collections.defaultdict().__reduce__()[4]).__name__
'dict_itemiterator'  # after
```

