### PR TITLE
int.to_bytes: compute the negative twos-complement bias with exact BigInt exponentiation (256n ** BigInt(len)), not BigInt(Math.pow(256, len)) which overflows to Infinity for len > ~128

### DIFF
--- a/www/src/py_int.js
+++ b/www/src/py_int.js
@@ -968,7 +968,7 @@ int_funcs.to_bytes = function(self) {
             $B.RAISE(_b_.OverflowError,
                 "can't convert negative int to unsigned")
         }
-        x = BigInt(Math.pow(256, len)) + x
+        x = (256n ** BigInt(len)) + x
     }
 
     var res = [],


### PR DESCRIPTION
```python
>>> (-1).to_bytes(129, "big", signed=True)[0]
JavascriptError: Infinity can't be converted to BigInt  # before
>>> (-1).to_bytes(129, "big", signed=True)[0]
255                                                     # after
```