### PR TITLE
id: value-identify only JS primitives and base float, not str/int/float subclass instances (real objects with their own identity), so two MyStr("x") get distinct ids

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1034,11 +1034,16 @@ _b_.id = function(obj) {
    check_nb_args_no_kw('id', 1, arguments)
    if (obj[$B.ID] !== undefined) {
        return obj[$B.ID]
-   } else if ($B.$isinstance(obj, [_b_.str, _b_.int, _b_.float])) {
-       return $B.$call($B.$getattr(_b_.str.$factory(obj), '__hash__'))
-   } else {
-       return obj[$B.ID] = $B.UUID()
    }
+   var t = typeof obj
+   if (t === 'string' || t === 'number' || t === 'bigint' ||
+           t === 'boolean' || $B.get_class(obj) === _b_.float) {
+       // JS primitives can't carry $B.ID, and a base float is value-identified;
+       // a str/int/float subclass instance is a distinct object, so it falls
+       // through to a per-instance UUID (else two MyStr("x") shared one id)
+       return $B.$call($B.$getattr(_b_.str.$factory(obj), '__hash__'))
+   }
+   return obj[$B.ID] = $B.UUID()
 }
 
 // The default __import__ function is a builtin


### PR DESCRIPTION
```python
>>> class S(str): pass
>>> x = S("x")
>>> y = S("x")
>>> id(x) == id(y)
True   # before
>>> id(x) == id(y)
False  # after
```