### PR TITLE
__import__: raise ValueError "Empty module name" for an empty name at level 0

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1049,6 +1049,9 @@ _b_.__import__ = function() {
         arguments,
         {globals:None, locals:None, fromlist:_b_.tuple.$factory(), level:0},
         null, null)
+    if ($.name === '' && $.level === 0) {
+        $B.RAISE(_b_.ValueError, "Empty module name")
+    }
     return $B.$__import__($.name, $.globals, $.locals, $.fromlist)
 }
 


### PR DESCRIPTION
```python
>>> __import__('')
JavascriptError: can't access property 0, fullname.match(...) is null  # before
>>> __import__('')
ValueError: Empty module name                                          # after
```