### PR TITLE
memoryview: toreadonly() returns a new read-only view (leaving the original writable) instead of mutating self.readonly and returning None

### DIFF
--- a/www/src/memoryobject.js
+++ b/www/src/memoryobject.js
@@ -493,7 +493,11 @@ memoryview_funcs.tolist = function(self) {
 }
 
 memoryview_funcs.toreadonly = function(self) {
-    self.readonly = 1
+    // return a new read-only view; the original stays writable (it mutated
+    // self and returned None, so memoryview(b).toreadonly() was unusable)
+    var res = memoryview.$factory(self.obj)
+    res.readonly = 1
+    return res
 }
 
 _b_.memoryview.tp_methods = ["release", "tobytes", "hex", "tolist", "cast", "toreadonly", "count", "index", "__enter__", "__exit__"]


### PR DESCRIPTION
```python
>>> memoryview(bytearray(b'abc')).toreadonly().readonly
AttributeError: Javascript object 'undefined' has no attribute     # before
>>> memoryview(bytearray(b'abc')).toreadonly().readonly
True                                                               # after
```
