### PR TITLE
map.$factory captures iterables like tp_new does, so a map built via map(...) is picklable: its __reduce__ dropped the iterables and the roundtrip failed

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1350,7 +1350,8 @@ map.$factory = function() {
     return {
         ob_type: map,
         args: iter_args,
-        func: func
+        func: func,
+        iterables: [$.it1, ...$.args]
     }
 }
 


### PR DESCRIPTION
finish #2853
```python
>>> import pickle
>>> list(pickle.loads(pickle.dumps(map(int, '12'))))
PicklingError: __reduce__ must return a string or tuple, not UndefinedType  # before
>>> list(pickle.loads(pickle.dumps(map(int, '12'))))
[1, 2]                                                                      # after
```