### PR TITLE
BytesIO.readinto writes into the buffer's backing source

### DIFF
--- a/www/src/libs/_io_classes.js
+++ b/www/src/libs/_io_classes.js
@@ -583,7 +583,11 @@ BytesIO_funcs.readinto = function(_self, buffer) {
             len = 0
         }
     }
-    var buf = $B.$isinstance(buffer, _b_.bytearray) ? buffer.source : buffer.obj
+    // write into the buffer's BACKING BYTES: a memoryview arrives as its
+    // wrapper object - buffer.obj is the underlying bytearray OBJECT, and
+    // numeric writes on it land on JS properties, not in .source
+    var target = $B.$isinstance(buffer, _b_.bytearray) ? buffer : buffer.obj
+    var buf = (target && target.source) ? target.source : target
     for (var i = 0; i < len; i++) {
         buf[i] = _self._buffer.source[_self._pos + i]
     }


### PR DESCRIPTION
```python
>>> import io
>>> mv = memoryview(bytearray(4))
>>> io.BytesIO(b'abcd').readinto(mv)
4
>>> bytes(mv)
b'\x00\x00\x00\x00'   # before
>>> bytes(mv)
b'abcd'               # after
```
