### PR TITLE
function.__module__ reads None after del, not an internal NULL object

### DIFF
--- a/www/src/py_functions.js
+++ b/www/src/py_functions.js
@@ -540,7 +540,8 @@ function_funcs.__kwdefaults___set = function(self, value) {
 }
 
 function_funcs.__module___get = function(self) {
-    return self.$function_infos[$B.func_attrs.__module__]
+    var res = self.$function_infos[$B.func_attrs.__module__]
+    return res === $B.NULL || res === undefined ? _b_.None : res
 }
 
 function_funcs.__module___set = function(self, value) {


### PR DESCRIPTION
```python
>>> def f(): pass
...
>>> del f.__module__
>>> print(f.__module__)
<Javascript object: [object Object]>   # before
>>> print(f.__module__)
None                                   # after
```
