### PR TITLE
len(): remove debug residue from the error message

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -1291,7 +1291,7 @@ var len = _b_.len = function(obj) {
     var method = $B.search_in_mro(klass, '__len__', null)
     if (method === null) {
         $B.RAISE(_b_.TypeError, "object of type '" +
-            $B.class_name(obj) + "' has no len() VVV")
+            $B.class_name(obj) + "' has no len()")
     }
 
     let res = $B.$call(method, obj)


### PR DESCRIPTION
```python
>>> len(3.14)
TypeError: object of type 'float' has no len() VVV   # before
>>> len(3.14)
TypeError: object of type 'float' has no len()       # after
```
