### PR TITLE
AttributeError on a module names the module

### DIFF
--- a/www/src/py_exceptions.js
+++ b/www/src/py_exceptions.js
@@ -854,6 +854,8 @@ $B.attr_error = function(name, obj) {
     var msg
     if ($B.is_type(obj)) {
         msg = `type object '${obj.tp_name}'`
+    } else if ($B.exact_type(obj, $B.module)) {
+        msg = `module '${$B.module_getattr(obj, '__name__')}'`
     } else {
         msg = `'${$B.class_name(obj)}' object`
     }


### PR DESCRIPTION
```python
>>> import os         
>>> os.spam
AttributeError: 'module' object has no attribute 'spam'   # before
>>> os.spam
AttributeError: module 'os' has no attribute 'spam'       # after
```
