### PR TITLE
functools.partial.__module__ is 'functools', not '_functools'

### DIFF
--- a/www/src/Lib/_functools.py
+++ b/www/src/Lib/_functools.py
@@ -78,6 +78,8 @@ class partial:
         self.args = args
         self.keywords = kwds
 
+partial.__module__ = 'functools'
+
 def reduce(func,iterable,initializer=None):
     args = iter(iterable)
     if initializer is not None:


### PR DESCRIPTION
```python
>>> import functools
>>> functools.partial.__module__
'_functools'   # before
>>> functools.partial.__module__
'functools'    # after
```