### PR TITLE
object.__reduce_ex__: look up __getnewargs_ex__ on the type, not the instance

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -144,9 +144,11 @@ object.$no_new_init = function(cls) {
 }
 
 function getNewArguments(self, klass) {
-    var newargs_ex = $B.$getattr(self, '__getnewargs_ex__', null)
+    // type-only lookup, like every implicit dunder: an instance getattr
+    // falls into a class __getattr__ hook on a miss
+    var newargs_ex = $B.$getattr(klass, '__getnewargs_ex__', null)
     if (newargs_ex !== null) {
-        let newargs = $B.$call(newargs_ex)
+        let newargs = $B.$call(newargs_ex, self)
         if ((! newargs) || $B.get_class(newargs) !== _b_.tuple) {
             $B.RAISE(_b_.TypeError, "__getnewargs_ex__ should " +
                 `return a tuple, not '${$B.class_name(newargs)}'`)


### PR DESCRIPTION
```python
>>> import pickle
>>> class BadGetattr:
...     def __getattr__(self, key):
...         self.foo
...
>>> type(pickle.dumps(BadGetattr(), 2)).__name__
RecursionError: maximum recursion depth exceeded   # before
>>> type(pickle.dumps(BadGetattr(), 2)).__name__
'bytes'                                            # after
```