### PR TITLE
unpack: drop the double space in "not enough values to unpack (expect…

### DIFF
--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -694,7 +694,7 @@ $B.unpacker = function(obj, nb_targets, has_starred) {
             (has_starred && (right_length < nb_targets - 1))){
         $B.set_inum(inum)
         var exc = $B.EXC(_b_.ValueError, `not enough values to unpack ` +
-            `(expected ${has_starred ? ' at least ' : ''} ` +
+            `(expected ${has_starred ? 'at least ' : ''}` +
             `${left_length}, got ${right_length})`)
         throw exc
     }


### PR DESCRIPTION
```python
>>> a, b, c = ()
ValueError: not enough values to unpack (expected  3, got 0)   # before
>>> a, b, c = ()
ValueError: not enough values to unpack (expected 3, got 0)    # after
```
