### PR TITLE
io.BufferedRandom: pass the raw through instead of returning the string "fileio"

### DIFF
--- a/www/src/libs/_io_classes.js
+++ b/www/src/libs/_io_classes.js
@@ -786,10 +786,12 @@ BufferedRWPair.$factory = function() {
 
 $B.finalize_type(BufferedRWPair)
 
-var BufferedRandom = $B.make_type("BufferedRandom", [$B._TextIOBase])
+var BufferedRandom = $B.make_type("BufferedRandom", [$B._BufferedIOBase])
 
-BufferedRandom.$factory = function() {
-    return "fileio"
+BufferedRandom.$factory = function(raw) {
+    // pass-through: the raw is already a usable read/write seekable file
+    // in the browser; buffer_size only affects chunking
+    return raw
 }
 
 $B.finalize_type(BufferedRandom)


### PR DESCRIPTION
```python
>>> import io
>>> io.BufferedRandom(io.BytesIO(), buffer_size=5).write(b'x')
AttributeError: 'str' object has no attribute 'write'   # before
>>> io.BufferedRandom(io.BytesIO(), buffer_size=5).write(b'x')
1                                                       # after
```