### PR TITLE
_socket.SocketType is the socket type, not a separate empty class

### DIFF
--- a/www/src/Lib/_socket.py
+++ b/www/src/Lib/_socket.py
@@ -235,8 +235,6 @@ SO_TYPE = 4104
 
 SO_USELOOPBACK = 64
 
-class SocketType:
-    pass
 
 TCP_MAXSEG = 4
 
@@ -390,3 +388,5 @@ class socket:
 
 class timeout:
     pass
+
+SocketType = socket


### PR DESCRIPTION
```python
>>> import _socket
>>> _socket.SocketType is _socket.socket
False   # before
>>> _socket.SocketType is _socket.socket
True    # after
```