### PR TITLE
a starred argument in a call goes through list.$unpack — f(a, *42) raises 'Value after * must be an iterable

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -1789,7 +1789,7 @@ function make_args(scopes) {
     for (let arg of this.args) {
         if (arg instanceof $B.ast.Starred) {
             var starred_arg = $B.js_from_ast(arg.value, scopes)
-            args_list.push(`...$B.make_js_iterator(${starred_arg})`)
+            args_list.push(`..._b_.list.$unpack(${starred_arg})`)
         } else {
             args_list.push($B.js_from_ast(arg, scopes))
         }


### PR DESCRIPTION
```python
>>> import functools
>>> functools.partial(int, *42)
TypeError: 'int' object is not iterable                 # before
>>> functools.partial(int, *42)
TypeError: Value after * must be an iterable, not int   # after
```