### PR TITLE
the ** non-mapping error gets CPython's parens and, when calling a class, the class qualified name instead of __call__

### DIFF
--- a/www/src/py_type.js
+++ b/www/src/py_type.js
@@ -1200,7 +1200,7 @@ _b_.type.tp_repr = function(kls) {
 }
 
 _b_.type.tp_call = function(cls) {
-    var $ = $B.args('__call__', 1, {cls: null}, arguments, null, 'args', 'kw'),
+    var $ = $B.args(cls?.tp_name ?? '__call__', 1, {cls: null}, arguments, null, 'args', 'kw'),
         cls = $.cls,
         args = $.args,
         kw = $.kw,

--- a/www/src/py_utils.js
+++ b/www/src/py_utils.js
@@ -334,7 +334,7 @@ $B.parse_kwargs = function(kw_args, fname) {
             try {
                 var keys_method = $B.$getattr(cls, 'keys')
             } catch (err) {
-                $B.RAISE(_b_.TypeError, `${fname} argument ` +
+                $B.RAISE(_b_.TypeError, `${fname}() argument ` +
                     `after ** must be a mapping, not ${$B.class_name(kw_arg)}`)
             }
             var keys_iter = $B.make_js_iterator($B.$call(keys_method, kw_arg)),


### PR DESCRIPTION
```python
>>> import functools
>>> functools.partial(int, **[])
TypeError: __call__ argument after ** must be a mapping, not list              # before
>>> functools.partial(int, **[])
TypeError: _functools.partial() argument after ** must be a mapping, not list   # after
```