### PR TITLE
the class-dict fast path in $B.$getattr yields to an inherited __getattribute__

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -828,7 +828,8 @@ $B.$getattr = function(obj, attr, _default) {
                 console.log('in klass dict', in_klass_dict)
                 console.log('in own dict', in_own_dict)
             }
-            if (in_klass_dict) {
+            if (in_klass_dict &&
+                    klass.$getattribute === _b_.object.tp_getattro) {
                 switch (in_klass_dict.ob_type) {
                     case $B.function:
                         if (in_own_dict === $B.NULL) {


### PR DESCRIPTION
```python
>>> class A:
...     def __getattribute__(self, name):
...         return 'intercepted'
>>> class B(A):
...     def m(self):
...         return 1
>>> B().m
<bound method B.m of <B object>>   # before
>>> B().m
'intercepted'                      # after
```