### PR TITLE
sys.getsizeof — delegate to __sizeof__ with CPython's default/TypeError semantics

### DIFF
--- a/www/src/builtin_modules.js
+++ b/www/src/builtin_modules.js
@@ -789,6 +789,20 @@
         getdefaultencoding: function() {
             return 'utf-8'
         },
+        getsizeof: function(obj, dflt) {
+            // delegate to __sizeof__, like CPython
+            try {
+                var res = $B.$call($B.$getattr(obj, '__sizeof__'))
+                if (typeof res == 'number' || typeof res == 'bigint') {
+                    return res
+                }
+            } catch (err) {}
+            if (dflt !== undefined) {
+                return dflt
+            }
+            $B.RAISE(_b_.TypeError,
+                "Type " + $B.class_name(obj) + " doesn't define __sizeof__")
+        },
         getrecursionlimit: function() {
             return $B.recursion_limit
         },

--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -1947,7 +1947,23 @@ str_funcs.__getnewargs__ = function(self) {
 }
 
 str_funcs.__sizeof__ = function(self) {
-    return 62
+    // CPython's 64-bit sizes (the platform Brython emulates — its hash
+    // width is 64): ASCII is a PyASCIIObject (40 bytes) + len + 1,
+    // otherwise PyCompactUnicodeObject (56 bytes) + (len + 1) * kind
+    var len = 0,
+        maxchar = 0
+    for (var c of to_string(self)) {
+        c = c.codePointAt(0)
+        if (c > maxchar) {
+            maxchar = c
+        }
+        len++
+    }
+    if (maxchar < 0x80) {
+        return 40 + len + 1
+    }
+    var kind = maxchar < 0x100 ? 1 : maxchar < 0x10000 ? 2 : 4
+    return 56 + (len + 1) * kind
 }
 
 str_funcs.capitalize = function(self) {


### PR DESCRIPTION
 ```python
>>> import sys
>>> sys.getsizeof('abc')
AttributeError: module 'sys' has no attribute 'getsizeof'   # before
>>> sys.getsizeof('abc')
44                                                          # after
```