### PR TITLE
bytearray/list slice assignment survives big payloads: the engine's call fail past ~125k elements; rebuild through 16K push chunks

### DIFF
--- a/www/src/py_bytes.js
+++ b/www/src/py_bytes.js
@@ -1296,7 +1296,22 @@ _b_.bytearray.sq_ass_item = function(self, arg, value) {
             }
         }
         // One splice only -> O(N+M) instead of O(N*M)
-        self.source.splice.apply(self.source, [start, 0].concat($temp))
+        if ($temp.length > 16384) {
+            // splice.apply passes every element as a JS argument: a big
+            // write (eg a 1 MB pickle frame through BytesIO) blows the
+            // engine's argument limit ("too many arguments provided for
+            // a function call"). Rebuild through 16K chunks instead.
+            var tail = self.source.slice(start)
+            self.source.length = start
+            for (var k = 0; k < $temp.length; k += 16384) {
+                self.source.push.apply(self.source, $temp.slice(k, k + 16384))
+            }
+            for (var k = 0; k < tail.length; k += 16384) {
+                self.source.push.apply(self.source, tail.slice(k, k + 16384))
+            }
+        } else {
+            self.source.splice.apply(self.source, [start, 0].concat($temp))
+        }
     } else {
         $B.RAISE(_b_.TypeError, 'list indices must be integer, not ' +
             $B.class_name(arg))

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -513,7 +513,19 @@ $B.list_reverseiterator.tp_methods = ["__length_hint__", "__reduce__", "__setsta
 // Set list key or slice
 function set_list_slice(obj, start, stop, value) {
     var res = _b_.list.$factory(value)
-    obj.splice.apply(obj,[start, stop - start].concat(res))
+    if (res.length > 16384) {
+        // same argument-limit hazard as the bytearray slice-assign
+        var tail = obj.slice(stop)
+        obj.length = start
+        for (var k = 0; k < res.length; k += 16384) {
+            obj.push.apply(obj, res.slice(k, k + 16384))
+        }
+        for (var k = 0; k < tail.length; k += 16384) {
+            obj.push.apply(obj, tail.slice(k, k + 16384))
+        }
+    } else {
+        obj.splice.apply(obj, [start, stop - start].concat(res))
+    }
 }
 
 function set_list_slice_step(obj, start, stop, step, value) {


### PR DESCRIPTION
```python
>>> ba = bytearray()
>>> ba[0:0] = bytes(1000000)
JavascriptError: too many arguments provided for a function call   # before
>>> ba[0:0] = bytes(1000000)
>>>                                                                # after
```