### PR TITLE
tokenizer: backslash-newline in an f-string literal part is a line continuation

### DIFF
--- a/www/src/python_tokenizer.js
+++ b/www/src/python_tokenizer.js
@@ -502,6 +502,13 @@ $B.tokenizer = function(src, filename, mode, parser) {
                     ft_buffer += '\\'
                 }
                 if (ft_escape) {
+                    if (char == '\n') {
+                        // backslash-newline is a line continuation: it does
+                        // not reach the string value (f"a\<newline>b" is 'ab')
+                        line_num++
+                        ft_escape = false
+                        continue
+                    }
                     ft_buffer += '\\'
                 }
                 ft_buffer += char


### PR DESCRIPTION
```python
>>> eval('f"a\\\nb"')
'a\\nb'  # before
>>> eval('f"a\\\nb"')
'ab'     # after
```