### PR TITLE
object.__sizeof__ was an empty function returning Javascript undefined

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -714,7 +714,10 @@ object_funcs.__reduce_ex__ = function(self, protocol) {
 }
 
 object_funcs.__sizeof__ = function(self) {
-
+    // CPython: _PyObject_SIZE(Py_TYPE(self)). 16 is the 64-bit build
+    // value (Brython emulates a 64-bit CPython; a 32-bit build, e.g.
+    // Pyodide, says 8)
+    return 16
 }
 
 object_funcs.__subclasshook__ = function(self) {


### PR DESCRIPTION
```python
>>> object.__sizeof__(object())
<Javascript undefined>  # before
>>> object.__sizeof__(object())
16                      # after
```