### PR TITLE
Abstract-class instantiation message: quote each missing method name and use a single space

### DIFF
--- a/www/src/py_object.js
+++ b/www/src/py_object.js
@@ -481,7 +481,7 @@ _b_.object.tp_new = function(cls, args, kw) {
         $B.RAISE(_b_.TypeError,
             `Can't instantiate abstract class ${$B.get_name(cls)} ` +
             `without an implementation for abstract method${plural} ` +
-            ` '${am.join(', ')}'`
+            am.map(m => `'${m}'`).join(', ')
         )
     }
     var res = {


### PR DESCRIPTION
```python
>>> import abc
>>> class A(metaclass=abc.ABCMeta):
...     @abc.abstractmethod
...     def f(self): ...
...     @abc.abstractmethod
...     def g(self): ...
...
>>> A()
TypeError: Can't instantiate abstract class A without an implementation for abstract methods  'f, g'  # before
>>> A()
TypeError: Can't instantiate abstract class A without an implementation for abstract methods 'f', 'g' # after
```
