### PR TITLE
with statement: the traceback of an exception raised in the body reported the line of the 'with' itself, not the raise

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -1531,12 +1531,14 @@ $B.ast.AsyncWith.prototype.to_js = function(scopes) {
         dedent()
         s += prefix + `} catch (err_${id}) {\n`
         indent()
-        s += prefix + `frame.$lineno = ${lineno}\n` +
-             prefix + `exc_${id} = false\n` +
+        s += prefix + `exc_${id} = false\n` +
              prefix + `err_${id} = $B.exception(err_${id}, frame)\n` +
+             prefix + `var lineno_${id} = frame.$lineno\n` +
+             prefix + `frame.$lineno = ${lineno}\n` +
              prefix + `var $b = await $B.promise(aexit_${id}(mgr_${id}, $B.get_class(err_${id}), \n` +
              prefix + tab.repeat(4) + `err_${id}, $B.$getattr(err_${id}, '__traceback__')))\n` +
              prefix + `if (! $B.$bool($b)) {\n` +
+             prefix + tab + `frame.$lineno = lineno_${id}\n` +
              prefix + tab + `throw err_${id}\n` +
              prefix + `}\n`
         dedent()
@@ -1544,8 +1546,8 @@ $B.ast.AsyncWith.prototype.to_js = function(scopes) {
         dedent()
         s += prefix + `}finally{\n`
         indent()
-        s += prefix + `frame.$lineno = ${lineno}\n` +
-             prefix + `if (exc_${id}) {\n` +
+        s += prefix + `if (exc_${id}) {\n` +
+             prefix + tab + `frame.$lineno = ${lineno}\n` +
              prefix + tab + `await $B.promise(aexit_${id}(mgr_${id}, _b_.None, _b_.None, _b_.None))\n` +
              prefix + `}\n`
         dedent()
@@ -4209,13 +4211,15 @@ $B.ast.With.prototype.to_js = function(scopes) {
         dedent()
         s += prefix + `} catch (err_${id}) {\n`
         indent()
-        s += prefix + `frame.$lineno = ${lineno}\n` +
-             prefix + `exc_${id} = false\n` +
+        s += prefix + `exc_${id} = false\n` +
              prefix + `err_${id} = $B.exception(err_${id}, frame)\n` +
+             prefix + `var lineno_${id} = frame.$lineno\n` +
+             prefix + `frame.$lineno = ${lineno}\n` +
              prefix + `var $b = $B.$call(exit_${id}, $B.get_class(err_${id}), ` +
                   `err_${id}, \n` +
              prefix + tab.repeat(4) + `$B.$getattr(err_${id}, '__traceback__'))\n` +
              prefix + `if (! $B.$bool($b)) {\n` +
+             prefix + tab + `frame.$lineno = lineno_${id}\n` +
              prefix + tab + `throw err_${id}\n` +
              prefix + `}\n`
         dedent()
@@ -4223,9 +4227,9 @@ $B.ast.With.prototype.to_js = function(scopes) {
         dedent()
         s += prefix + `}finally{\n`
         indent()
-        s += prefix + `frame.$lineno = ${lineno}\n` +
-             (in_generator ? prefix + `locals.$context_managers.pop()\n` : '') +
-             prefix + `if (exc_${id}) {\n`
+        s += (in_generator ? prefix + `locals.$context_managers.pop()\n` : '') +
+             prefix + `if (exc_${id}) {\n` +
+             prefix + tab + `frame.$lineno = ${lineno}\n`
         indent()
         s += prefix + `try {\n` +
              prefix + tab + `$B.$call(exit_${id}, _b_.None, _b_.None, _b_.None)\n` +


### PR DESCRIPTION
```python
>>> from contextlib import nullcontext
>>> def f():
...     with nullcontext():
...         raise ValueError
...
>>> def line_of(fn):
...     try:
...         fn()
...     except ValueError as e:
...         tb = e.__traceback__
...         while tb.tb_next: tb = tb.tb_next
...         return tb.tb_lineno
...
>>> line_of(f)
2  # before
>>> line_of(f)
3  # after
```