### PR TITLE
compiler_error crashed on a filename absent from file_cache (TypeError: Cannot read properties of undefined (reading 'split') instead of the intended SyntaxError)

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -90,9 +90,10 @@ function compiler_error(ast_obj, message, end) {
     prefix = ''
     var exc = $B.EXC(_b_.SyntaxError, message)
     exc.filename = state.filename
-    if (exc.filename != '<string>') {
-        var src = $B.file_cache[exc.filename],
-            lines = src.split('\n'),
+    var src = exc.filename == '<string>' ?
+        undefined : $B.file_cache[exc.filename]
+    if (src !== undefined) {
+        var lines = src.split('\n'),
             line = lines[ast_obj.lineno - 1]
         exc.text = line
     } else {


### PR DESCRIPTION
```js
const $B = __BRYTHON__
$B.py2js("continue", "app.py", "app").to_js()
TypeError: Cannot read properties of undefined (reading 'split')   // before
$B.py2js("continue", "app.py", "app").to_js()
SyntaxError: 'continue' not properly in loop                       // after
```