### PR TITLE
Improve compatibility between turtle.FormattedTuple and stdlib's turtle.Vec2D (turtle star)

### DIFF
--- a/www/src/Lib/turtle.py
+++ b/www/src/Lib/turtle.py
@@ -76,6 +76,8 @@ class FormattedTuple(tuple):
         return tuple.__new__(cls, (x, y))
     def __repr__(self):
         return "(%.2f, %.2f)" % self
+    def __abs__(self):
+        return math.hypot(*self)
 
 def create_circle(r):
     '''Creates a circle of radius r centered at the origin'''


### PR DESCRIPTION
Turtle module docs intro contains [following script](https://docs.python.org/3/library/turtle.html#making-algorithmic-patterns) for drawing turtle star:

```python
color('red')
fillcolor('yellow')

begin_fill()
while True:
    forward(200)
    left(170)
    if abs(pos()) < 1:
        break

end_fill()
done()
```
It draws correctly with tkinter, but `abs(pos()) < 1` fails with `TypeError: Bad operand type for abs(): 'FormattedTuple'` for Brython (and Basthon).

Fix by copying over `__abs__` method implementation for stdlib. `__abs__` method returns the absolute value of the point.