### PR TITLE
Run terser with -c and -m in make_minified.py

### DIFF
--- a/scripts/make_minified.py
+++ b/scripts/make_minified.py
@@ -7,6 +7,6 @@ from directories import src_dir
 
 this_dir = os.getcwd()
 os.chdir(src_dir)
-if os.system('terser brython.js -o brython.min.js'):
+if os.system('terser brython.js -c -m -o brython.min.js'):
     raise SystemError('could not create brython.min.js')
 os.chdir(this_dir)


### PR DESCRIPTION
    terser is invoked with no options, so it re-prints the file instead of
    compressing it: brython.js is 1 406 617 bytes and brython.min.js is
    1 351 125, a 3.9% gain. The input is already stripped of whitespace and
    comments by scripts/javascript_minifier.py, so there is nothing left for
    a bare terser pass to remove.
    
    Adding -c (compress) and -m (mangle) does the work the step was added
    for: dead code elimination, constant folding, and renaming of local
    identifiers.
    
        brython.min.js today      1 351 125 B   gzip 261 555 B
        with -c -m                  943 743 B   gzip 220 970 B
                                      -30.2%         -15.5%