### PR TITLE
Return a Python list from convert_to_python, not a bare Array

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -457,7 +457,7 @@ function convert_to_python(obj) {
         return obj
     }
     if (Array.isArray(obj)) {
-        return obj.map(convert_to_python)
+        return _b_.list.$factory(obj.map(convert_to_python))
     }
     if ($B.$isinstance(obj, $B.JSObj)) {
         if (typeof obj == 'number') {


### PR DESCRIPTION
```python
>>> from browser import window
>>> d = window.JSON.parse('{"nodes": [1, 2], "meta": {"k": 1}}').to_dict()
>>> type(d["nodes"]).__name__, isinstance(d["nodes"], list), repr(d["nodes"])
('JavascriptArray', False, '[1, 2]')   # before
>>> type(d["nodes"]).__name__, isinstance(d["nodes"], list), repr(d["nodes"])
('list', True, '[1, 2]')               # after
```