### PR TITLE
Hold the Python back-reference in a WeakMap instead of a symbol property

### DIFF
--- a/www/src/js_objects.js
+++ b/www/src/js_objects.js
@@ -120,6 +120,10 @@ $B.structuredclone2pyobj = function(obj) {
 
 const JSOBJ = $B.JSOBJ = Symbol('JSOBJ')
 const PYOBJ = $B.PYOBJ = Symbol('PYOBJ')
+// The back-reference is held here rather than as a property on the JavaScript
+// object: an own symbol key makes the object unusable as a WebIDL record, which
+// is what `new Response(body, {headers})` and `new Headers(obj)` take.
+const PYOBJ_MAP = $B.PYOBJ_MAP = new WeakMap()
 const PYOBJFCT = Symbol('PYOBJFCT')
 const PYOBJFCTS = Symbol('PYOBJFCTS')
 
@@ -194,7 +198,7 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this) {
 
     let pyobj
     try {
-        pyobj = jsobj[PYOBJ]
+        pyobj = PYOBJ_MAP.get(jsobj)
     } catch (err) {
         // ignore and return jsobj. Cf. issue #2692
         return jsobj
@@ -304,7 +308,7 @@ var jsobj2pyobj = $B.jsobj2pyobj = function(jsobj, _this) {
 
     if ($B.$isNode(jsobj)) {
         const res = $B.DOMNode.$factory(jsobj)
-        jsobj[PYOBJ] = res
+        PYOBJ_MAP.set(jsobj, res)
         res[JSOBJ] = jsobj
         return res
     }
@@ -345,7 +349,7 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj) {
     if (has_type(klass, _b_.list) || has_type(klass, _b_.tuple)) {
         // Python list : transform its elements
         var jsobj = pyobj.map(pyobj2jsobj)
-        jsobj[PYOBJ] = pyobj
+        PYOBJ_MAP.set(jsobj, pyobj)
         delete jsobj.ob_type // becomes a js_array
         return jsobj
     }
@@ -369,7 +373,7 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj) {
             jsobj[key] = pyobj2jsobj(entry.value)
         }
         pyobj[JSOBJ] = jsobj
-        jsobj[PYOBJ] = pyobj
+        PYOBJ_MAP.set(jsobj, pyobj)
         return jsobj
     }
 
@@ -405,7 +409,7 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj) {
             }
 
             pyobj[JSOBJ] = jsobj
-            jsobj[PYOBJ] = pyobj
+            PYOBJ_MAP.set(jsobj, pyobj)
 
             return jsobj
         }
@@ -438,7 +442,7 @@ var pyobj2jsobj = $B.pyobj2jsobj = function(pyobj) {
         }
 
         pyobj[JSOBJ] = jsobj
-        jsobj[PYOBJ] = pyobj
+        PYOBJ_MAP.set(jsobj, pyobj)
 
         return jsobj
     }
@@ -1253,8 +1257,9 @@ var js_array_funcs = js_array.tp_funcs = {}
 
 js_array_funcs.append = function(self, x) {
     self.push(pyobj2jsobj(x))
-    if (self[PYOBJ]) {
-        self[PYOBJ].push(x)
+    const pyobj = PYOBJ_MAP.get(self)
+    if (pyobj) {
+        pyobj.push(x)
     }
     return _b_.None
 }

--- a/www/src/py_dom.js
+++ b/www/src/py_dom.js
@@ -662,8 +662,8 @@ DOMNode.tp_getattro = function(self, attr) {
             return res
         }
         if (typeof res === "function") {
-            if (Object.hasOwn(res, $B.PYOBJ)) {
-                return res[$B.PYOBJ]
+            if ($B.PYOBJ_MAP.has(res)) {
+                return $B.PYOBJ_MAP.get(res)
             }
             if (self.ob_type && self.ob_type.$webcomponent) {
                 var method = $B.$getattr($B.get_class(self), attr, null)

--- a/www/src/py_list.js
+++ b/www/src/py_list.js
@@ -350,8 +350,8 @@ $B.list_iterator.tp_methods = ["__length_hint__", "__reduce__", "__setstate__"]
 /* list_iterator end */
 
 var eq = $B.list_eq = function(self, other) {
-    if (other[$B.PYOBJ]) {
-        other = other[$B.PYOBJ]
+    if ($B.PYOBJ_MAP.has(other)) {
+        other = $B.PYOBJ_MAP.get(other)
     }
     var cls = $B.$isinstance(self, list) ? list : tuple
     if (isinstance(other, cls)) {


### PR DESCRIPTION
`pyobj2jsobj` leaves a back-reference on the converted object, `jsobj[PYOBJ] = pyobj`. An own symbol key makes that object unusable as a WebIDL `record<K, V>`, which is what `Headers`, `URLSearchParams` and `new Response(body, {headers})` take. Making the property non-enumerable does not help — a record conversion walks own keys before it filters on enumerability.

```python
>>> from browser import window
>>> h = {"content-type": "application/json"}
>>> window.Response.new("x", {"headers": h})
JavascriptError: can't convert symbol to string   # before
>>> window.Response.new("x", {"headers": h})
<Response 200>                                    # after
```