### PR TITLE
Report the position of each f-string chunk, not of the token that opened it

### DIFF
--- a/www/src/python_tokenizer.js
+++ b/www/src/python_tokenizer.js
@@ -377,6 +377,7 @@ $B.tokenizer = function(src, filename, mode, parser) {
         ft_expr_start,
         ft_escape,
         ft_format_spec,
+        ft_chunk_start,
         braces_length_on_entry,
         fstring_stack = [],
         debug = 0
@@ -405,9 +406,11 @@ $B.tokenizer = function(src, filename, mode, parser) {
         if (token_mode != save_mode) {
             if (token_mode == 'ft') {
                 ft_buffer = ''
+                ft_chunk_start = pos - line_start - char.length + 1
                 ft_escape = false
             } else if (token_mode == 'format_specifier') {
                 format_specifier = ''
+                ft_chunk_start = pos - line_start - char.length + 1
             }
         }
         save_mode = token_mode
@@ -430,8 +433,8 @@ $B.tokenizer = function(src, filename, mode, parser) {
                 if (ft_buffer.length > 0) {
                     // emit FSTRING_MIDDLE token
                     t.push(Token(FT_MIDDLE[ft_type], ft_buffer,
-                        line_num, ft_start,
-                        line_num, ft_start + ft_buffer.length,
+                        line_num, ft_chunk_start,
+                        line_num, pos - line_start - char.length + 1,
                         line))
                 }
                 t.push(Token(FT_END[ft_type], char, line_num, pos - line_start,
@@ -459,8 +462,8 @@ $B.tokenizer = function(src, filename, mode, parser) {
                     // emit FSTRING_MIDDLE if not empty
                     if (ft_buffer.length > 0) {
                         t.push(Token(FT_MIDDLE[ft_type], ft_buffer,
-                            line_num, ft_start,
-                            line_num, ft_start + ft_buffer.length,
+                            line_num, ft_chunk_start,
+                            line_num, pos - line_start - char.length + 1,
                             line))
                     }
                     token_mode = 'regular_within_ft'
@@ -523,8 +526,8 @@ $B.tokenizer = function(src, filename, mode, parser) {
                 if (format_specifier.length > 0) {
                     // emit FSTRING_MIDDLE token
                     t.push(Token(FT_MIDDLE[ft_type], format_specifier,
-                        line_num, ft_start,
-                        line_num, ft_start + format_specifier.length,
+                        line_num, ft_chunk_start,
+                        line_num, pos - line_start - char.length + 1,
                         line))
                     // pop from token modes
                     token_modes.pop()
@@ -534,8 +537,8 @@ $B.tokenizer = function(src, filename, mode, parser) {
             } else if (char == '{') {
                 if (format_specifier.length > 0) {
                     t.push(Token(FT_MIDDLE[ft_type], format_specifier,
-                        line_num, ft_start,
-                        line_num, ft_start + format_specifier.length,
+                        line_num, ft_chunk_start,
+                        line_num, pos - line_start - char.length + 1,
                         line))
                 }
                 token_mode = 'regular_within_ft'
@@ -552,8 +555,8 @@ $B.tokenizer = function(src, filename, mode, parser) {
             } else if (char == '}') {
                 // emit FSTRING_MIDDLE
                 t.push(Token(FT_MIDDLE[ft_type], format_specifier,
-                    line_num, ft_start,
-                    line_num, ft_start + format_specifier.length,
+                    line_num, ft_chunk_start,
+                    line_num, pos - line_start - char.length + 1,
                     line))
                 // emit closing bracket token
                 t.push(Token('OP', char,


### PR DESCRIPTION
```python
>>> from browser import window
>>> B = window.__BRYTHON__
>>> [(t.string, t.col_offset, t.end_col_offset) for t in B.tokenizer('x = f"ab{v}cd"\n', "p", "file") if t.type == 60]
[('ab', 4, 6), ('cd', 4, 6)]      # before
>>> [(t.string, t.col_offset, t.end_col_offset) for t in B.tokenizer('x = f"ab{v}cd"\n', "p", "file") if t.type == 60]
[('ab', 6, 8), ('cd', 11, 13)]    # after
```
