### PR TITLE
Neutralise every character invalid in an identifier in qualified_scope_name

### DIFF
--- a/www/src/ast_to_js.js
+++ b/www/src/ast_to_js.js
@@ -244,7 +244,7 @@ function qualified_scope_name(scopes, scope) {
             names.push(_scope.name)
         }
     }
-    return names.join('_').replace(/\./g, '_')
+    return names.join('_').replace(/[^\w$]/g, '_')
 }
 
 function show_flags(name, flag) {


### PR DESCRIPTION
```python
>>> from browser import window
>>> B = window.__BRYTHON__
>>> js = B.py2js({"src": "x = 1\n", "filename": "a/b.py"}, "m", ["m"]).to_js()
>>> [w for w in js.split() if w.startswith("locals_")][0]
'locals_a/b_py'   # before
>>> [w for w in js.split() if w.startswith("locals_")][0]
'locals_a_b_py'   # after
```
