### PR TITLE
Convert the start argument of str.find to a JavaScript position

### DIFF
--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -2196,7 +2196,7 @@ str_funcs.find = function(self, sub, start, end) {
             'slice indices must be integers or None or have an __index__ ' +
             'method')
     }
-    res = self.indexOf(sub, start)
+    res = self.indexOf(sub, pypos2jspos(self, start))
     if (end !== _b_.None) {
         try {
             end = $B.PyNumber_Index(end)


### PR DESCRIPTION
```python
>>> s = 'a\U0001f600bXbX'
>>> s.find('X', 4)
3  # before
>>> s.find('X', 4)
5  # after
```
