### PR TITLE
Fix find negative start

### DIFF
--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -2196,6 +2196,9 @@ str_funcs.find = function(self, sub, start, end) {
             'slice indices must be integers or None or have an __index__ ' +
             'method')
     }
+    if (start < 0) {
+        start = Math.max(0, start + str.mp_length(self))
+    }
     res = self.indexOf(sub, pypos2jspos(self, start))
     if (end !== _b_.None) {
         try {

--- a/www/src/py_string.js
+++ b/www/src/py_string.js
@@ -2196,7 +2196,7 @@ str_funcs.find = function(self, sub, start, end) {
             'slice indices must be integers or None or have an __index__ ' +
             'method')
     }
-    res = self.indexOf(sub, start)
+    res = self.indexOf(sub, pypos2jspos(self, start))
     if (end !== _b_.None) {
         try {
             end = $B.PyNumber_Index(end)


### PR DESCRIPTION
```python
>>> s = 'abXbX'
>>> s.find('X', -2)
2  # before
>>> s.find('X', -2)
4  # after
```
